### PR TITLE
Add quick home return on title/menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -48,6 +48,7 @@ document.addEventListener("DOMContentLoaded", () => {
     const dropdownMenu = document.getElementById("title-dropdown");
     dropdownTrigger.addEventListener("click", () => {
         dropdownMenu.classList.toggle("show");
+        switchTool("home");
     });
 
     // Toggle hamburger menu
@@ -58,6 +59,7 @@ document.addEventListener("DOMContentLoaded", () => {
         const expanded = hamburger.getAttribute("aria-expanded") === "true" || false;
         hamburger.setAttribute("aria-expanded", !expanded);
         mainNavLinks.classList.toggle("show");
+        switchTool("home");
     });
 
     // Update time display every second


### PR DESCRIPTION
## Summary
- switch to home section when clicking the site title or hamburger menu

## Testing
- `node routine.test.js` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_684f0ba607448321be8328f35fdf3a81