### PR TITLE
Revamp routine tool layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -594,12 +594,12 @@
                 <h2>Routine Tool</h2>
                 <p>Create, manage, and run daily routines with timed tasks.</p>
 
-                <div class="routine-view-controls" style="margin-bottom: 1rem; text-align: center;">
+                <div class="routine-view-controls" >
                     <button id="routine-show-player-btn" class="btn btn-primary active" aria-pressed="true">Run Routine</button>
                     <button id="routine-show-setup-btn" class="btn btn-secondary" aria-pressed="false">Manage Routines</button>
                 </div>
 
-                <div class="routine-container">
+                <div class="routine-container routine-layout">
                     <div class="routine-setup routine-section-hidden">
                         <h3>Create & Manage Routines</h3>
                         <div class="input-group">
@@ -635,7 +635,7 @@
                         <h3>Active Routine</h3>
                         <div id="active-routine-display">
                             <h4 id="current-routine-name">No routine selected/active</h4>
-                            <ul id="current-routine-tasks">
+                            <ul id="current-routine-tasks" class="routine-task-list">
                                 <!-- Tasks will be listed here -->
                             </ul>
                             <p>Expected Finish Time: <span id="expected-finish-time">-</span></p>

--- a/styles.css
+++ b/styles.css
@@ -629,6 +629,57 @@ footer {
     flex-direction: column;
     gap: 1rem;
 }
+/* Routine Tool Layout */
+.routine-view-controls {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.routine-layout {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.routine-setup,
+.routine-player {
+    background-color: var(--surface);
+    padding: 1rem;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+}
+
+@media (min-width: 768px) {
+    .routine-layout {
+        grid-template-columns: 1fr 1fr;
+        align-items: start;
+    }
+}
+
+.routine-task-list {
+    list-style: none;
+    padding: 0;
+}
+
+.routine-task-list li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid #eee;
+}
+
+.routine-task-list li:last-child {
+    border-bottom: none;
+}
+
+.routine-task-actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.routine-section-hidden {
+    display: none;
+}
 
 /* Responsive adjustments for day planner */
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- modernize Routine Tool HTML structure
- add dedicated styles for Routine Tool layout and task list

## Testing
- `node -e "require('./routine.js'); const test=require('./routine.test.js'); if(global.runRoutineTests) global.runRoutineTests();"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_684fa0575f448321894404b2076a5ed2