### PR TITLE
Enable long-press import on mobile

### DIFF
--- a/day-planner.js
+++ b/day-planner.js
@@ -127,6 +127,24 @@ document.addEventListener('DOMContentLoaded', function() {
                     localStorage.setItem(`day-planner-${timeKey}`, eventContent.innerHTML);
                     updateSlotStyles();
                 });
+
+                // Long-press on smartphones to import a breakdown step
+                let pressTimer;
+                const longPressDuration = 600; // ms
+                const startPress = () => {
+                    if (window.innerWidth <= 480) {
+                        pressTimer = setTimeout(() => {
+                            openModal();
+                            eventTimeSelect.value = timeKey;
+                            importTaskSelect.focus();
+                        }, longPressDuration);
+                    }
+                };
+                const cancelPress = () => clearTimeout(pressTimer);
+                eventContent.addEventListener('touchstart', startPress);
+                eventContent.addEventListener('touchend', cancelPress);
+                eventContent.addEventListener('touchmove', cancelPress);
+                eventContent.addEventListener('touchcancel', cancelPress);
                 timeBlock.appendChild(eventContent);
 
                 rowContainer.appendChild(timeBlock);

--- a/styles.css
+++ b/styles.css
@@ -725,4 +725,9 @@ footer {
         min-height: 40px;
         font-size: 0.8rem;
     }
+
+    /* Hide breakdown icon on small screens */
+    .breakdown-import-btn {
+        display: none;
+    }
 }


### PR DESCRIPTION
## Summary
- hide breakdown import icon on small screens
- support long press on time blocks in Day Planner to import breakdown steps

## Testing
- `node routine.test.js` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_684fb7875dec83219e15f55bbe4faba5