### PR TITLE
Improve mobile menu layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,63 +74,54 @@
                     <div class="tool-card" data-tool="pomodoro">
                         <div class="tool-icon"><i class="fas fa-clock"></i></div>
                         <h3>Pomodoro Timer</h3>
-                        <p>Work in focused sprints with timed breaks to maintain productivity.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="eisenhower">
                         <div class="tool-icon"><i class="fas fa-th-large"></i></div>
                         <h3>Eisenhower Matrix</h3>
-                        <p>Prioritize tasks based on importance and urgency.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="planner">
                         <div class="tool-icon"><i class="fas fa-calendar-alt"></i></div>
                         <h3>Day Planner</h3>
-                        <p>Visualize your day with time blocks for better time management.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="tasks">
                         <div class="tool-icon"><i class="fas fa-tasks"></i></div>
                         <h3>Task Manager</h3>
-                        <p>Keep track of your to-do list with priorities and categories.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="breakdown">
                         <div class="tool-icon"><i class="fas fa-project-diagram"></i></div>
                         <h3>Task Breakdown</h3>
-                        <p>Break complex tasks into smaller, manageable steps.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="habits">
                         <div class="tool-icon"><i class="fas fa-check-square"></i></div>
                         <h3>Habit Tracker</h3>
-                        <p>Build consistency with daily habit tracking and streaks.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="routine">
                         <div class="tool-icon"><i class="fas fa-tasks-alt"></i></div>
                         <h3>Routine Tool</h3>
-                        <p>Plan and execute sequences of tasks with timers.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="focus">
                         <div class="tool-icon"><i class="fas fa-eye"></i></div>
                         <h3>Focus Mode</h3>
-                        <p>Minimize distractions with a clean, focused interface.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="rewards">
                         <div class="tool-icon"><i class="fas fa-trophy"></i></div>
                         <h3>Rewards</h3>
-                        <p>Celebrate your accomplishments with visual rewards.</p>
                         <button class="btn">Open Tool</button>
                     </div>
                 </div>

--- a/styles.css
+++ b/styles.css
@@ -485,6 +485,10 @@ footer {
     .timer-controls { flex-direction: column; }
     header .container > p { display: none; }
     .current-time { margin-top: 0.25rem; }
+    .tools-grid { grid-template-columns: repeat(3, 1fr); gap: 1rem; }
+    .tool-card { padding: 0.75rem; }
+    .tool-icon { font-size: 1.5rem; margin-bottom: 0.25rem; }
+    .tool-card h3 { font-size: 0.9rem; margin-bottom: 0.25rem; }
     /* Eisenhower small tweaks */
     .matrix-grid { grid-template-columns: 60px 1fr 1fr; font-size: 0.85rem; }
     .matrix-header-cell, .matrix-cell { padding: 0.5rem; }


### PR DESCRIPTION
## Summary
- remove descriptions from tool cards on the home screen
- add responsive layout for small screens so all icons show at once

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684fb81dfc608321ac4a8eae0f06cde9