### PR TITLE
Add routine tool info and clickable icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 Interactive tools to help manage ADHD symptoms and improve productivity.
 
+## Quick Links
+
+[![Pomodoro](icons/pomodoro.svg)](https://jobellet.github.io/ADHDtools/#pomodoro)
+[![Eisenhower Matrix](icons/eisenhower.svg)](https://jobellet.github.io/ADHDtools/#eisenhower)
+[![Day Planner](icons/planner.svg)](https://jobellet.github.io/ADHDtools/#planner)
+[![Task Manager](icons/task-manager.svg)](https://jobellet.github.io/ADHDtools/#tasks)
+[![Task Breakdown](icons/task-breakdown.svg)](https://jobellet.github.io/ADHDtools/#breakdown)
+[![Habit Tracker](icons/habit-tracker.svg)](https://jobellet.github.io/ADHDtools/#habits)
+[![Routine Tool](icons/routine.svg)](https://jobellet.github.io/ADHDtools/#routine)
+[![Focus Mode](icons/focus-mode.svg)](https://jobellet.github.io/ADHDtools/#focus)
+[![Rewards](icons/rewards.svg)](https://jobellet.github.io/ADHDtools/#rewards)
+
 ## Features
 
 *   **Pomodoro Timer:** Work in focused sprints with timed breaks to maintain productivity.
@@ -12,6 +24,7 @@ Interactive tools to help manage ADHD symptoms and improve productivity.
 *   **Task Manager:** Keep track of your to-do list with priorities and categories.
 *   **Task Breakdown:** Break complex tasks into smaller, manageable steps.
 *   **Habit Tracker:** Build consistency with daily habit tracking and streaks.
+*   **Routine Tool:** Create and run daily routines with timed tasks.
 *   **Focus Mode:** Minimize distractions with a clean, focused interface.
 *   **Rewards:** Celebrate your accomplishments with visual rewards.
 

--- a/icons/eisenhower.svg
+++ b/icons/eisenhower.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#6f42c1"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">E</text>
+</svg>

--- a/icons/focus-mode.svg
+++ b/icons/focus-mode.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#8bc34a"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">F</text>
+</svg>

--- a/icons/habit-tracker.svg
+++ b/icons/habit-tracker.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#5cb85c"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">H</text>
+</svg>

--- a/icons/planner.svg
+++ b/icons/planner.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#0275d8"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">D</text>
+</svg>

--- a/icons/pomodoro.svg
+++ b/icons/pomodoro.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#d9534f"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">P</text>
+</svg>

--- a/icons/rewards.svg
+++ b/icons/rewards.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#ffcc00"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">W</text>
+</svg>

--- a/icons/routine.svg
+++ b/icons/routine.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#343a40"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">R</text>
+</svg>

--- a/icons/task-breakdown.svg
+++ b/icons/task-breakdown.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#f0ad4e"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">B</text>
+</svg>

--- a/icons/task-manager.svg
+++ b/icons/task-manager.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="12" ry="12" fill="#5bc0de"/>
+  <text x="64" y="84" font-size="72" text-anchor="middle" fill="white" font-family="Arial">T</text>
+</svg>


### PR DESCRIPTION
## Summary
- document Routine Tool in features list
- add local SVG logos and link them to each tool's section

## Testing
- `node routine.test.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684fb9f5e0448321af990a6e6e4e7ec5