### PR TITLE
Remove header tool dropdown and use grid for nav

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,6 @@ document.addEventListener("DOMContentLoaded", () => {
     const toolCards = document.querySelectorAll(".tool-card");
     const toolSections = document.querySelectorAll(".tool-section");
     const navLinks = document.querySelectorAll("nav a[data-tool]");
-    const dropdownLinks = document.querySelectorAll("#title-dropdown a[data-tool]");
     const currentTimeDisplay = document.getElementById("current-time-display");
 
     function switchTool(toolName) {
@@ -35,21 +34,6 @@ document.addEventListener("DOMContentLoaded", () => {
         });
     });
 
-    dropdownLinks.forEach(link => {
-        link.addEventListener("click", (e) => {
-            e.preventDefault();
-            const toolName = link.dataset.tool;
-            switchTool(toolName);
-        });
-    });
-
-    // Show dropdown on title click
-    const dropdownTrigger = document.querySelector(".dropdown-trigger");
-    const dropdownMenu = document.getElementById("title-dropdown");
-    dropdownTrigger.addEventListener("click", () => {
-        dropdownMenu.classList.toggle("show");
-        switchTool("home");
-    });
 
     // Toggle hamburger menu
     const hamburger = document.querySelector(".hamburger-menu");

--- a/index.html
+++ b/index.html
@@ -23,22 +23,7 @@
 <body>
     <header>
         <div class="container">
-            <h1 id="site-title" class="dropdown-trigger"><i class="fas fa-brain"></i> ADHD Tools Hub</h1>
-            <div id="title-dropdown" class="title-dropdown">
-                <ul>
-                    <li><a href="#" data-tool="home"><i class="fas fa-home"></i> Home</a></li>
-                    <li><a href="#" data-tool="pomodoro"><i class="fas fa-clock"></i> Pomodoro Timer</a></li>
-                    <li><a href="#" data-tool="eisenhower"><i class="fas fa-th-large"></i> Eisenhower Matrix</a></li>
-                    <li><a href="#" data-tool="planner"><i class="fas fa-calendar-alt"></i> Day Planner</a></li>
-                    <li><a href="#" data-tool="tasks"><i class="fas fa-tasks"></i> Task Manager</a></li>
-                    <li><a href="#" data-tool="breakdown"><i class="fas fa-project-diagram"></i> Task Breakdown</a></li>
-                    <li><a href="#" data-tool="habits"><i class="fas fa-check-square"></i> Habit Tracker</a></li>
-                    <li><a href="#" data-tool="routine"><i class="fas fa-tasks-alt"></i> Routine Tool</a></li>
-                    <li><a href="#" data-tool="focus"><i class="fas fa-eye"></i> Focus Mode</a></li>
-                    <li><a href="#" data-tool="rewards"><i class="fas fa-trophy"></i> Rewards</a></li>
-                    <li><a href="#" data-tool="about"><i class="fas fa-info-circle"></i> About</a></li>
-                </ul>
-            </div>
+            <h1 id="site-title"><i class="fas fa-brain"></i> ADHD Tools Hub</h1>
             <p>Interactive tools to help manage ADHD symptoms and improve productivity</p>
             <span id="current-time-display" class="current-time"></span>
         </div>

--- a/styles.css
+++ b/styles.css
@@ -133,13 +133,15 @@ nav {
 }
 
 nav ul {
-    display: flex;
-    flex-wrap: wrap;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.5rem;
     justify-content: center;
+    padding: 0;
 }
 
 nav li {
-    margin: 0 0.5rem;
+    margin: 0;
 }
 
 nav a {
@@ -147,6 +149,7 @@ nav a {
     padding: 1rem;
     color: var(--on-surface);
     border-bottom: 3px solid transparent;
+    text-align: center;
 }
 
 nav a:hover, nav a.active {
@@ -437,33 +440,34 @@ footer {
         position: relative; /* Ensure container is positioned */
     }
     
-    nav ul#main-nav-links { 
-        display: none; 
-        flex-direction: column; 
-        position: absolute; 
-        top: 100%; 
-        left: 0; 
-        right: 0; 
-        background: var(--surface); 
+    nav ul#main-nav-links {
+        display: none;
+        grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
+        gap: 0.5rem;
+        position: absolute;
+        top: 100%;
+        left: 0;
+        right: 0;
+        background: var(--surface);
         box-shadow: var(--box-shadow);
         padding: 10px 0;
         z-index: 99;
     }
-    
-    nav ul#main-nav-links.nav-open { 
-        display: flex; 
+
+    nav ul#main-nav-links.nav-open {
+        display: grid;
     }
-    
+
     nav ul#main-nav-links li {
-        width: 100%;
         margin: 0;
     }
-    
+
     nav ul#main-nav-links li a {
         padding: 12px 20px;
         width: 100%;
         border-bottom: none;
         border-left: 3px solid transparent;
+        text-align: center;
     }
     
     nav ul#main-nav-links li a:hover,


### PR DESCRIPTION
## Summary
- clean up header by removing old dropdown list
- lay out nav menu using responsive grid so icons fit on any screen
- delete dropdown code from app.js

## Testing
- `node routine.test.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_684fbbfd22a4832190a29678887a60d7