### PR TITLE
Remove unused Open Tool buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,55 +59,46 @@
                     <div class="tool-card" data-tool="pomodoro">
                         <div class="tool-icon"><i class="fas fa-clock"></i></div>
                         <h3>Pomodoro Timer</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="eisenhower">
                         <div class="tool-icon"><i class="fas fa-th-large"></i></div>
                         <h3>Eisenhower Matrix</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="planner">
                         <div class="tool-icon"><i class="fas fa-calendar-alt"></i></div>
                         <h3>Day Planner</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="tasks">
                         <div class="tool-icon"><i class="fas fa-tasks"></i></div>
                         <h3>Task Manager</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="breakdown">
                         <div class="tool-icon"><i class="fas fa-project-diagram"></i></div>
                         <h3>Task Breakdown</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="habits">
                         <div class="tool-icon"><i class="fas fa-check-square"></i></div>
                         <h3>Habit Tracker</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="routine">
                         <div class="tool-icon"><i class="fas fa-tasks-alt"></i></div>
                         <h3>Routine Tool</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="focus">
                         <div class="tool-icon"><i class="fas fa-eye"></i></div>
                         <h3>Focus Mode</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                     
                     <div class="tool-card" data-tool="rewards">
                         <div class="tool-icon"><i class="fas fa-trophy"></i></div>
                         <h3>Rewards</h3>
-                        <button class="btn">Open Tool</button>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- remove 'Open Tool' buttons so tool cards themselves remain clickable

## Testing
- `node routine.test.js` (no output expected)

------
https://chatgpt.com/codex/tasks/task_e_684fef940dd483218e9e519959135b4d