### PR TITLE
Add calendar tool with ICS import

### DIFF
--- a/calendar-tool.js
+++ b/calendar-tool.js
@@ -1,0 +1,146 @@
+// calendar-tool.js
+// Simple Calendar tool with ICS import
+
+(function() {
+  const STORAGE_KEY = 'adhd-calendar-events';
+
+  // Parse dates from ICS format (very simplified)
+  function parseICSTime(value) {
+    if (!value) return '';
+    // Remove timezone specifiers like ;VALUE=DATE or Z
+    value = value.replace(/^(?:DATE-TIME:|VALUE=DATE:)?/, '');
+    // collapse to plain string
+    const match = value.match(/(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2}))?/);
+    if (!match) return '';
+    const [ , y,m,d, , hh,mm,ss ] = match;
+    if (hh !== undefined) {
+      return `${y}-${m}-${d}T${hh || '00'}:${mm || '00'}:${ss || '00'}` + (value.endsWith('Z') ? 'Z' : '');
+    }
+    return `${y}-${m}-${d}`;
+  }
+
+  // Minimal ICS parser focusing on VEVENT blocks
+  function parseICS(text) {
+    // handle line continuations
+    text = text.replace(/\r?\n[ \t]/g, '');
+    const lines = text.split(/\r?\n/);
+    const events = [];
+    let current = null;
+    lines.forEach(line => {
+      if (line === 'BEGIN:VEVENT') {
+        current = {};
+      } else if (line === 'END:VEVENT') {
+        if (current) events.push(current);
+        current = null;
+      } else if (current) {
+        const idx = line.indexOf(':');
+        if (idx === -1) return;
+        const key = line.substring(0, idx).split(';')[0];
+        const value = line.substring(idx + 1);
+        switch (key) {
+          case 'SUMMARY':
+            current.title = value;
+            break;
+          case 'DESCRIPTION':
+            current.description = value;
+            break;
+          case 'DTSTART':
+            current.start = parseICSTime(value);
+            break;
+          case 'DTEND':
+            current.end = parseICSTime(value);
+            break;
+          case 'LOCATION':
+            current.location = value;
+            break;
+          case 'UID':
+            current.uid = value;
+            break;
+        }
+      }
+    });
+    return events;
+  }
+
+  function loadEvents() {
+    try {
+      return JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+    } catch {
+      return [];
+    }
+  }
+
+  function saveEvents(events) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+  }
+
+  // Render simple list of events
+  function render(events) {
+    const list = document.getElementById('calendar-events');
+    if (!list) return;
+    list.innerHTML = '';
+    events.sort((a,b) => new Date(a.start) - new Date(b.start));
+    events.forEach(ev => {
+      const div = document.createElement('div');
+      div.className = 'calendar-event';
+      const time = ev.start ? new Date(ev.start).toLocaleString() : '';
+      div.textContent = `${time} - ${ev.title}`;
+
+      // button to send as task
+      if (window.CrossTool && window.CrossTool.sendTaskToTool) {
+        const btn = document.createElement('button');
+        btn.textContent = 'Send to Task Manager';
+        btn.addEventListener('click', () => {
+          const duration = ev.start && ev.end ? Math.round((new Date(ev.end) - new Date(ev.start))/60000) : 0;
+          const task = {
+            id: window.CrossTool.generateId(),
+            text: ev.title,
+            originalTool: 'Calendar',
+            dueDate: ev.start ? ev.start.split('T')[0] : '',
+            duration,
+            notes: ev.description || ''
+          };
+          window.CrossTool.sendTaskToTool(task, 'TaskManager');
+        });
+        div.appendChild(btn);
+      }
+
+      list.appendChild(div);
+    });
+  }
+
+  function handleICSFile(file, events) {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = e => {
+      try {
+        const parsed = parseICS(e.target.result);
+        parsed.forEach(ev => ev.id = window.CrossTool ? window.CrossTool.generateId() : 'ev-' + Date.now());
+        events = events.concat(parsed);
+        saveEvents(events);
+        render(events);
+        alert(`Imported ${parsed.length} events.`);
+      } catch (err) {
+        console.error('ICS import failed', err);
+        alert('Failed to import ICS file');
+      }
+    };
+    reader.readAsText(file);
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const container = document.querySelector('.calendar-container');
+    if (!container) return;
+
+    let events = loadEvents();
+    render(events);
+
+    const fileInput = document.getElementById('ics-file-input');
+    const importBtn = document.getElementById('import-ics-btn');
+
+    if (importBtn && fileInput) {
+      importBtn.addEventListener('click', () => fileInput.click());
+      fileInput.addEventListener('change', e => handleICSFile(e.target.files[0], events));
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <script src="focus-mode.js" defer></script>
     <script src="reward-system.js" defer></script>
     <script src="cross-tool-interaction.js" defer></script>
+    <script src="calendar-tool.js" defer></script>
     <script src="data-management.js" defer></script>
     <script src="routine.js" defer></script>
     <script src="script-loader.js" defer></script>
@@ -37,6 +38,7 @@
                 <li><a href="#" data-tool="pomodoro"><i class="fas fa-clock"></i> Pomodoro Timer</a></li>
                 <li><a href="#" data-tool="eisenhower"><i class="fas fa-th-large"></i> Eisenhower Matrix</a></li>
                 <li><a href="#" data-tool="planner"><i class="fas fa-calendar-alt"></i> Day Planner</a></li>
+                <li><a href="#" data-tool="calendar"><i class="fas fa-calendar"></i> Calendar</a></li>
                 <li><a href="#" data-tool="tasks"><i class="fas fa-tasks"></i> Task Manager</a></li>
                 <li><a href="#" data-tool="breakdown"><i class="fas fa-project-diagram"></i> Task Breakdown</a></li>
                 <li><a href="#" data-tool="habits"><i class="fas fa-check-square"></i> Habit Tracker</a></li>
@@ -70,7 +72,12 @@
                         <div class="tool-icon"><i class="fas fa-calendar-alt"></i></div>
                         <h3>Day Planner</h3>
                     </div>
-                    
+
+                    <div class="tool-card" data-tool="calendar">
+                        <div class="tool-icon"><i class="fas fa-calendar"></i></div>
+                        <h3>Calendar</h3>
+                    </div>
+
                     <div class="tool-card" data-tool="tasks">
                         <div class="tool-icon"><i class="fas fa-tasks"></i></div>
                         <h3>Task Manager</h3>
@@ -250,6 +257,17 @@
                 </div>
             </section>
 
+            <!-- Calendar Section -->
+            <section id="calendar" class="tool-section">
+                <h2>Calendar</h2>
+                <p>Import calendar events from ICS files and manage them with other tools.</p>
+
+                <div class="calendar-container">
+                    <button id="import-ics-btn" class="btn">Import ICS</button>
+                    <input type="file" id="ics-file-input" accept=".ics" style="display:none">
+                    <div id="calendar-events" class="calendar-events-list"></div>
+                </div>
+            </section>
 
             <!-- Task Manager Section -->
             <section id="tasks" class="tool-section">

--- a/styles.css
+++ b/styles.css
@@ -882,7 +882,23 @@ footer {
     }
 
     /* Hide breakdown icon on small screens */
-    .breakdown-import-btn {
-        display: none;
-    }
+.breakdown-import-btn {
+    display: none;
+}
+
+/* Calendar tool */
+.calendar-events-list {
+    margin-top: 1rem;
+}
+
+.calendar-event {
+    padding: 0.25rem 0;
+    border-bottom: 1px solid #ddd;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.calendar-event button {
+    margin-left: 0.5rem;
+}
 }


### PR DESCRIPTION
## Summary
- add a simple calendar tool that can import ICS files
- include a parser converting ICS events to the site's JSON format
- expose the calendar via new navigation link and section
- style the calendar event list

## Testing
- `node routine.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6853041111708321a3497b35a28a4abd