### PR TITLE
Add calendar day/week/month views

### DIFF
--- a/calendar-tool.js
+++ b/calendar-tool.js
@@ -3,6 +3,8 @@
 
 (function() {
   const STORAGE_KEY = 'adhd-calendar-events';
+  let currentView = 'day';
+  let referenceDate = new Date();
 
   // Parse dates from ICS format (very simplified)
   function parseICSTime(value) {
@@ -74,39 +76,156 @@
     localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
   }
 
-  // Render simple list of events
   function render(events) {
-    const list = document.getElementById('calendar-events');
-    if (!list) return;
-    list.innerHTML = '';
+    const container = document.getElementById('calendar-view');
+    if (!container) return;
+    container.innerHTML = '';
     events.sort((a,b) => new Date(a.start) - new Date(b.start));
-    events.forEach(ev => {
-      const div = document.createElement('div');
-      div.className = 'calendar-event';
-      const time = ev.start ? new Date(ev.start).toLocaleString() : '';
-      div.textContent = `${time} - ${ev.title}`;
+    switch (currentView) {
+      case 'week':
+        renderWeek(events, container);
+        break;
+      case 'month':
+        renderMonth(events, container);
+        break;
+      default:
+        renderDay(events, container);
+    }
+  }
 
-      // button to send as task
-      if (window.CrossTool && window.CrossTool.sendTaskToTool) {
-        const btn = document.createElement('button');
-        btn.textContent = 'Send to Task Manager';
-        btn.addEventListener('click', () => {
-          const duration = ev.start && ev.end ? Math.round((new Date(ev.end) - new Date(ev.start))/60000) : 0;
-          const task = {
-            id: window.CrossTool.generateId(),
-            text: ev.title,
-            originalTool: 'Calendar',
-            dueDate: ev.start ? ev.start.split('T')[0] : '',
-            duration,
-            notes: ev.description || ''
-          };
-          window.CrossTool.sendTaskToTool(task, 'TaskManager');
-        });
-        div.appendChild(btn);
-      }
-
-      list.appendChild(div);
+  function createTaskButton(ev) {
+    if (!(window.CrossTool && window.CrossTool.sendTaskToTool)) return null;
+    const btn = document.createElement('button');
+    btn.textContent = 'Send to Task Manager';
+    btn.addEventListener('click', () => {
+      const duration = ev.start && ev.end ? Math.round((new Date(ev.end) - new Date(ev.start))/60000) : 0;
+      const task = {
+        id: window.CrossTool.generateId(),
+        text: ev.title,
+        originalTool: 'Calendar',
+        dueDate: ev.start ? ev.start.split('T')[0] : '',
+        duration,
+        notes: ev.description || ''
+      };
+      window.CrossTool.sendTaskToTool(task, 'TaskManager');
     });
+    return btn;
+  }
+
+  function renderDay(events, container) {
+    const dayStr = referenceDate.toISOString().split('T')[0];
+    const dayEvents = events.filter(ev => ev.start && ev.start.startsWith(dayStr));
+    const table = document.createElement('table');
+    table.className = 'calendar-table';
+    table.innerHTML = '<thead><tr><th>Time</th><th>Event</th></tr></thead>';
+    const tbody = document.createElement('tbody');
+    dayEvents.forEach(ev => {
+      const tr = document.createElement('tr');
+      const timeCell = document.createElement('td');
+      timeCell.textContent = ev.start ? new Date(ev.start).toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'}) : '';
+      const titleCell = document.createElement('td');
+      titleCell.textContent = ev.title;
+      const btn = createTaskButton(ev);
+      if (btn) titleCell.appendChild(btn);
+      tr.appendChild(timeCell);
+      tr.appendChild(titleCell);
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    container.appendChild(table);
+  }
+
+  function renderWeek(events, container) {
+    const start = new Date(referenceDate);
+    const day = (start.getDay() + 6) % 7; // Monday=0
+    start.setDate(start.getDate() - day);
+    const headerRow = document.createElement('tr');
+    for (let i=0;i<7;i++) {
+      const d = new Date(start);
+      d.setDate(start.getDate()+i);
+      const th = document.createElement('th');
+      th.textContent = d.toLocaleDateString(undefined, {weekday:'short', month:'short', day:'numeric'});
+      headerRow.appendChild(th);
+    }
+    const table = document.createElement('table');
+    table.className = 'calendar-table';
+    const thead = document.createElement('thead');
+    thead.appendChild(headerRow);
+    const tbody = document.createElement('tbody');
+    const row = document.createElement('tr');
+    for (let i=0;i<7;i++) {
+      const cellDate = new Date(start);
+      cellDate.setDate(start.getDate()+i);
+      const cell = document.createElement('td');
+      const dayStr = cellDate.toISOString().split('T')[0];
+      if (dayStr === new Date().toISOString().split('T')[0]) cell.classList.add('today');
+      const list = document.createElement('ul');
+      events.filter(ev => ev.start && ev.start.startsWith(dayStr)).forEach(ev => {
+        const li = document.createElement('li');
+        const time = ev.start ? new Date(ev.start).toLocaleTimeString([], {hour:'2-digit', minute:'2-digit'}) + ' ' : '';
+        li.textContent = time + ev.title;
+        const btn = createTaskButton(ev);
+        if (btn) li.appendChild(btn);
+        list.appendChild(li);
+      });
+      cell.appendChild(list);
+      row.appendChild(cell);
+    }
+    tbody.appendChild(row);
+    table.appendChild(thead);
+    table.appendChild(tbody);
+    container.appendChild(table);
+  }
+
+  function renderMonth(events, container) {
+    const year = referenceDate.getFullYear();
+    const month = referenceDate.getMonth();
+    const first = new Date(year, month, 1);
+    const startOffset = (first.getDay() + 6) % 7; // Monday index
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const table = document.createElement('table');
+    table.className = 'calendar-table';
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    for (let i=0;i<7;i++) {
+      const d = new Date(first);
+      d.setDate(first.getDate() - startOffset + i);
+      const th = document.createElement('th');
+      th.textContent = d.toLocaleDateString(undefined, {weekday:'short'});
+      headRow.appendChild(th);
+    }
+    thead.appendChild(headRow);
+    table.appendChild(thead);
+    const tbody = document.createElement('tbody');
+    let current = 1 - startOffset;
+    for (let r=0;r<6;r++) {
+      const tr = document.createElement('tr');
+      for (let c=0;c<7;c++) {
+        const cellDate = new Date(year, month, current);
+        const cell = document.createElement('td');
+        if (current >= 1 && current <= daysInMonth) {
+          const dayStr = cellDate.toISOString().split('T')[0];
+          const num = document.createElement('div');
+          num.textContent = cellDate.getDate();
+          cell.appendChild(num);
+          const list = document.createElement('ul');
+          events.filter(ev => ev.start && ev.start.startsWith(dayStr)).forEach(ev => {
+            const li = document.createElement('li');
+            li.textContent = ev.title;
+            const btn = createTaskButton(ev);
+            if (btn) li.appendChild(btn);
+            list.appendChild(li);
+          });
+          cell.appendChild(list);
+          if (dayStr === new Date().toISOString().split('T')[0]) cell.classList.add('today');
+        }
+        tr.appendChild(cell);
+        current++;
+      }
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    container.appendChild(table);
   }
 
   function handleICSFile(file, events) {
@@ -134,6 +253,18 @@
 
     let events = loadEvents();
     render(events);
+
+    const defaultBtn = container.querySelector('.calendar-view-btn[data-view="' + currentView + '"]');
+    if (defaultBtn) defaultBtn.classList.add('active');
+
+    container.querySelectorAll('.calendar-view-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        currentView = btn.dataset.view;
+        container.querySelectorAll('.calendar-view-btn').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        render(events);
+      });
+    });
 
     const fileInput = document.getElementById('ics-file-input');
     const importBtn = document.getElementById('import-ics-btn');

--- a/index.html
+++ b/index.html
@@ -263,9 +263,14 @@
                 <p>Import calendar events from ICS files and manage them with other tools.</p>
 
                 <div class="calendar-container">
+                    <div class="calendar-controls">
+                        <button data-view="day" class="calendar-view-btn btn">Day</button>
+                        <button data-view="week" class="calendar-view-btn btn">Week</button>
+                        <button data-view="month" class="calendar-view-btn btn">Month</button>
+                    </div>
                     <button id="import-ics-btn" class="btn">Import ICS</button>
                     <input type="file" id="ics-file-input" accept=".ics" style="display:none">
-                    <div id="calendar-events" class="calendar-events-list"></div>
+                    <div id="calendar-view" class="calendar-events-list"></div>
                 </div>
             </section>
 

--- a/styles.css
+++ b/styles.css
@@ -901,4 +901,29 @@ footer {
 .calendar-event button {
     margin-left: 0.5rem;
 }
+
+/* New calendar views */
+.calendar-controls {
+    margin-bottom: 0.5rem;
+}
+.calendar-view-btn {
+    margin-right: 0.25rem;
+}
+.calendar-view-btn.active {
+    background-color: var(--primary-color);
+    color: #fff;
+}
+.calendar-table {
+    width: 100%;
+    border-collapse: collapse;
+}
+.calendar-table th,
+.calendar-table td {
+    border: 1px solid #ddd;
+    padding: 4px;
+    vertical-align: top;
+}
+.calendar-table td.today {
+    background-color: #f0f8ff;
+}
 }


### PR DESCRIPTION
## Summary
- default to showing today's events
- add day, week and month views in calendar tool
- update styles for new calendar tables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685307b696908321b357e837dcca56d4