### PR TITLE
Enable cross-tool task export

### DIFF
--- a/cross-tool-interaction.js
+++ b/cross-tool-interaction.js
@@ -95,6 +95,25 @@
     getStore: () => JSON.parse(JSON.stringify(store)),
 
     /**
+     * Programmatically switch the interface to a given tool.
+     * Mirrors the switchTool logic in app.js so other modules can
+     * change the active section when passing data around.
+     * @param {string} toolName - id of the tool section to activate
+     */
+    openTool: function(toolName) {
+      if (!toolName) return;
+      const sections = document.querySelectorAll('.tool-section');
+      const navLinks = document.querySelectorAll('nav a[data-tool]');
+      sections.forEach(sec => sec.classList.remove('active'));
+      const target = document.getElementById(toolName);
+      if (target) {
+        target.classList.add('active');
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+      }
+      navLinks.forEach(link => link.classList.toggle('active', link.dataset.tool === toolName));
+    },
+
+    /**
      * Standardized Task Object Structure:
      * {
      *   id: string, // Unique identifier (generate if needed)
@@ -138,6 +157,20 @@
       const eventName = `ef-receiveTaskFor-${targetTool}`;
       console.log(`CrossTool: Dispatching event '${eventName}' with task:`, taskObject);
       this.bus.dispatchEvent(new CustomEvent(eventName, { detail: taskObject }));
+      this.openTool(targetTool);
+    },
+
+    /**
+     * Send multiple tasks at once to a tool.
+     * @param {Array<object>} tasks - array of task objects
+     * @param {string} targetTool - identifier of the target tool
+     */
+    sendTasksToTool: function(tasks, targetTool) {
+      if (!Array.isArray(tasks)) {
+        console.error('CrossTool.sendTasksToTool: tasks must be an array');
+        return;
+      }
+      tasks.forEach(task => this.sendTaskToTool(task, targetTool));
     }
   };
 })();

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="app.js" defer></script>
+    <script src="cross-tool-interaction.js" defer></script>
     <script src="pomodoro.js" defer></script>
     <script src="eisenhower.js" defer></script>
     <script src="day-planner.js" defer></script>
@@ -15,7 +16,6 @@
     <script src="habit-tracker.js" defer></script>
     <script src="focus-mode.js" defer></script>
     <script src="reward-system.js" defer></script>
-    <script src="cross-tool-interaction.js" defer></script>
     <script src="calendar-tool.js" defer></script>
     <script src="data-management.js" defer></script>
     <script src="routine.js" defer></script>


### PR DESCRIPTION
## Summary
- move `cross-tool-interaction.js` near the top of the scripts list so the
  EventBus is available immediately
- enhance cross-tool API with `openTool` and `sendTasksToTool`
- automatically open the target tool when sending a task

## Testing
- `node routine.test.js` *(fails: no output)*

------
https://chatgpt.com/codex/tasks/task_e_68531412e8548321a39242bfe4f9b79e