### PR TITLE
Add Google calendar URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,17 @@ The Calendar tool can load `.ics` files exported from other apps like Google Cal
 
 Only simple events are supported and nothing is uploaded anywhere.
 
+### Loading a Public Google Calendar
+
+Instead of manually exporting files, you can fetch events directly from a public link:
+
+1. In **Google Calendar** open **Settings** and choose your calendar under **Settings for my calendars**.
+2. Under **Access permissions for events** check **Make available to public** (Google warns that everything will be visible to anyone with the link).
+3. Go to **Integrate calendar** and copy the **Public address in iCal format**.
+4. In the Calendar tool paste this link into the **Load ICS URL** field and click **Load ICS URL**. Events will refresh automatically every 30 seconds.
+
+**Privacy Risks:** anyone who has this link can view your calendar details. Share it carefully. To change the link later, disable public sharing (uncheck **Make available to public**) and enable it again to generate a new address or use **Reset private URLs** under **Integrate calendar**.
+
 
 ## License
 

--- a/calendar-tool.js
+++ b/calendar-tool.js
@@ -3,9 +3,11 @@
 
 (function() {
   const STORAGE_KEY = 'adhd-calendar-events';
+  const ICS_URL_KEY = 'adhd-calendar-ics-url';
   let currentView = 'day';
   let referenceDate = new Date();
   let events = [];
+  let icsUrl = '';
 
   // Parse dates from ICS format (very simplified)
   function parseICSTime(value) {
@@ -72,6 +74,18 @@
     } catch {
       return [];
     }
+  }
+
+  function loadIcsUrl() {
+    try {
+      return localStorage.getItem(ICS_URL_KEY) || '';
+    } catch {
+      return '';
+    }
+  }
+
+  function saveIcsUrl(url) {
+    localStorage.setItem(ICS_URL_KEY, url);
   }
 
   function saveEvents(events) {
@@ -265,11 +279,27 @@
     reader.readAsText(file);
   }
 
+  async function handleICSUrl(url) {
+    if (!url) return;
+    try {
+      const resp = await fetch(url);
+      const text = await resp.text();
+      const parsed = parseICS(text);
+      parsed.forEach(ev => ev.id = window.CrossTool ? window.CrossTool.generateId() : 'ev-' + Date.now());
+      events = removeDuplicateEvents(events.concat(parsed));
+      saveEvents(events);
+      render(events);
+    } catch (err) {
+      console.error('ICS fetch failed', err);
+    }
+  }
+
   document.addEventListener('DOMContentLoaded', () => {
     const container = document.querySelector('.calendar-container');
     if (!container) return;
 
     events = loadEvents();
+    icsUrl = loadIcsUrl();
     render(events);
 
     const defaultBtn = container.querySelector('.calendar-view-btn[data-view="' + currentView + '"]');
@@ -291,10 +321,29 @@
 
     const fileInput = document.getElementById('ics-file-input');
     const importBtn = document.getElementById('import-ics-btn');
+    const urlInput = document.getElementById('ics-url');
+    const loadUrlBtn = document.getElementById('load-ics-url-btn');
+
+    if (urlInput) urlInput.value = icsUrl;
+
+    if (loadUrlBtn && urlInput) {
+      loadUrlBtn.addEventListener('click', () => {
+        icsUrl = urlInput.value.trim();
+        saveIcsUrl(icsUrl);
+        handleICSUrl(icsUrl);
+      });
+    }
 
     if (importBtn && fileInput) {
       importBtn.addEventListener('click', () => fileInput.click());
       fileInput.addEventListener('change', e => handleICSFile(e.target.files[0]));
+    }
+
+    if (icsUrl) {
+      handleICSUrl(icsUrl);
+      setInterval(() => {
+        handleICSUrl(icsUrl);
+      }, 30000);
     }
   });
 })();

--- a/index.html
+++ b/index.html
@@ -272,6 +272,10 @@
                     </div>
                     <button id="import-ics-btn" class="btn">Import ICS</button>
                     <input type="file" id="ics-file-input" accept=".ics" style="display:none">
+                    <div class="ics-url-input">
+                        <input type="url" id="ics-url" placeholder="https://...ics">
+                        <button id="load-ics-url-btn" class="btn">Load ICS URL</button>
+                    </div>
                     <div id="calendar-view" class="calendar-events-list"></div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- enable loading Google Calendar via public ICS link
- refresh calendar events every 30 seconds
- add ICS URL input in calendar UI
- document how to share a public Google Calendar and privacy considerations

## Testing
- `node -e "require('./calendar-tool.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6861160ad6788321b7f53b157548d188