### PR TITLE
Add calendar voice alerts

### DIFF
--- a/calendar-tool.js
+++ b/calendar-tool.js
@@ -4,10 +4,16 @@
 (function() {
   const STORAGE_KEY = 'adhd-calendar-events';
   const ICS_URL_KEY = 'adhd-calendar-ics-url';
+  const VOICE_ENABLED_KEY = 'adhd-calendar-voice-enabled';
+  const VOICE_EARLY_KEY = 'adhd-calendar-voice-early';
   let currentView = 'day';
   let referenceDate = new Date();
   let events = [];
   let icsUrl = '';
+  let voiceEnabled = false;
+  let voiceEarly = 0; // minutes before event
+  const announcedEarly = new Set();
+  const announcedStart = new Set();
 
   // Parse dates from ICS format (very simplified)
   function parseICSTime(value) {
@@ -84,6 +90,22 @@
     }
   }
 
+  function loadVoiceSettings() {
+    try {
+      voiceEnabled = localStorage.getItem(VOICE_ENABLED_KEY) === 'true';
+      voiceEarly = parseInt(localStorage.getItem(VOICE_EARLY_KEY) || '0', 10);
+      if (isNaN(voiceEarly)) voiceEarly = 0;
+    } catch {
+      voiceEnabled = false;
+      voiceEarly = 0;
+    }
+  }
+
+  function saveVoiceSettings() {
+    localStorage.setItem(VOICE_ENABLED_KEY, voiceEnabled);
+    localStorage.setItem(VOICE_EARLY_KEY, voiceEarly);
+  }
+
   function saveIcsUrl(url) {
     localStorage.setItem(ICS_URL_KEY, url);
   }
@@ -100,6 +122,43 @@
       seen.add(key);
       return true;
     });
+  }
+
+  function speak(text) {
+    if (!voiceEnabled || !('speechSynthesis' in window)) return;
+    const utter = new SpeechSynthesisUtterance(text);
+    utter.lang = document.documentElement.lang || 'en';
+    window.speechSynthesis.speak(utter);
+  }
+
+  function checkVoiceAnnouncements() {
+    if (!voiceEnabled) return;
+    const now = new Date();
+    events.forEach(ev => {
+      if (!ev.start) return;
+      const start = new Date(ev.start);
+      if (isNaN(start)) return;
+      const diffMin = (start - now) / 60000;
+      if (diffMin <= voiceEarly && diffMin > voiceEarly - 1 && !announcedEarly.has(ev.id + '-' + voiceEarly)) {
+        const msg = getAnnouncement('soon', ev.title, Math.round(diffMin));
+        speak(msg);
+        announcedEarly.add(ev.id + '-' + voiceEarly);
+      }
+      if (diffMin <= 0 && diffMin > -1 && !announcedStart.has(ev.id)) {
+        const msg = getAnnouncement('now', ev.title, 0);
+        speak(msg);
+        announcedStart.add(ev.id);
+      }
+    });
+  }
+
+  function getAnnouncement(type, title, minutes) {
+    const lang = document.documentElement.lang || 'en';
+    const dict = (window.translations && window.translations[lang]) || {};
+    let template = '';
+    if (type === 'soon') template = dict['calendar-announcement-soon'] || 'Event "{title}" starts in {minutes} minutes.';
+    else template = dict['calendar-announcement-now'] || 'Event "{title}" is starting now.';
+    return template.replace('{title}', title).replace('{minutes}', minutes);
   }
 
   function render(events) {
@@ -300,6 +359,7 @@
 
     events = loadEvents();
     icsUrl = loadIcsUrl();
+    loadVoiceSettings();
     render(events);
 
     const defaultBtn = container.querySelector('.calendar-view-btn[data-view="' + currentView + '"]');
@@ -334,6 +394,24 @@
       });
     }
 
+    const voiceCheckbox = document.getElementById('calendar-voice-enable');
+    const voiceEarlyInput = document.getElementById('calendar-voice-early');
+    if (voiceCheckbox) {
+      voiceCheckbox.checked = voiceEnabled;
+      voiceCheckbox.addEventListener('change', () => {
+        voiceEnabled = voiceCheckbox.checked;
+        saveVoiceSettings();
+      });
+    }
+    if (voiceEarlyInput) {
+      voiceEarlyInput.value = voiceEarly;
+      voiceEarlyInput.addEventListener('change', () => {
+        const val = parseInt(voiceEarlyInput.value, 10);
+        voiceEarly = isNaN(val) ? 0 : val;
+        saveVoiceSettings();
+      });
+    }
+
     if (importBtn && fileInput) {
       importBtn.addEventListener('click', () => fileInput.click());
       fileInput.addEventListener('change', e => handleICSFile(e.target.files[0]));
@@ -345,5 +423,7 @@
         handleICSUrl(icsUrl);
       }, 30000);
     }
+
+    setInterval(checkVoiceAnnouncements, 60000);
   });
 })();

--- a/i18n.js
+++ b/i18n.js
@@ -34,6 +34,10 @@ const translations = {
     'planner-text': 'Visualize your day with time blocks for better time management. Plan your activities hour by hour to stay organized.',
     'calendar-heading': 'Calendar',
     'calendar-text': 'Import calendar events from ICS files and manage them with other tools.',
+    'calendar-voice-label': 'Voice alerts',
+    'calendar-voice-early-label': 'Minutes early:',
+    'calendar-announcement-now': 'Event "{title}" is starting now.',
+    'calendar-announcement-soon': 'Event "{title}" starts in {minutes} minutes.',
     'tasks-heading': 'Task Manager',
     'tasks-text': 'Keep track of your to-do list with priorities and categories. Organize your tasks to ensure nothing falls through the cracks.',
     'breakdown-heading': 'Task Breakdown',
@@ -108,6 +112,10 @@ const translations = {
     'planner-text': "Visualisez votre journée avec des blocs de temps pour mieux la gérer. Planifiez vos activités heure par heure pour rester organisé.",
     'calendar-heading': 'Calendrier',
     'calendar-text': 'Importez des événements au format ICS et gérez-les avec les autres outils.',
+    'calendar-voice-label': 'Alertes vocales',
+    'calendar-voice-early-label': 'Minutes avant :',
+    'calendar-announcement-now': "L'événement \"{title}\" commence maintenant.",
+    'calendar-announcement-soon': "L'événement \"{title}\" commence dans {minutes} minutes.",
     'tasks-heading': 'Gestionnaire de tâches',
     'tasks-text': "Suivez vos tâches avec des priorités et des catégories. Organisez-les pour n'en oublier aucune.",
     'breakdown-heading': 'Décomposition des tâches',
@@ -182,6 +190,10 @@ const translations = {
     'planner-text': 'Visualisiere deinen Tag in Zeitblöcken für ein besseres Zeitmanagement.',
     'calendar-heading': 'Kalender',
     'calendar-text': 'Importiere Termine aus ICS-Dateien und verwalte sie mit anderen Werkzeugen.',
+    'calendar-voice-label': 'Sprachbenachrichtigungen',
+    'calendar-voice-early-label': 'Minuten vorher:',
+    'calendar-announcement-now': 'Termin "{title}" beginnt jetzt.',
+    'calendar-announcement-soon': 'Termin "{title}" beginnt in {minutes} Minuten.',
     'tasks-heading': 'Aufgabenmanager',
     'tasks-text': 'Behalte deine Aufgaben mit Prioritäten und Kategorien im Blick, damit nichts untergeht.',
     'breakdown-heading': 'Aufgaben zerlegen',
@@ -256,6 +268,10 @@ const translations = {
     'planner-text': 'Visualiza tu día con bloques de tiempo para gestionarlo mejor.',
     'calendar-heading': 'Calendario',
     'calendar-text': 'Importa eventos en formato ICS y gestiónalos con otras herramientas.',
+    'calendar-voice-label': 'Alertas de voz',
+    'calendar-voice-early-label': 'Minutos antes:',
+    'calendar-announcement-now': 'El evento "{title}" comienza ahora.',
+    'calendar-announcement-soon': 'El evento "{title}" comienza en {minutes} minutos.',
     'tasks-heading': 'Gestor de tareas',
     'tasks-text': 'Lleva un seguimiento de tus tareas con prioridades y categorías para que nada se pierda.',
     'breakdown-heading': 'Desglose de tareas',
@@ -296,6 +312,11 @@ const translations = {
     'footer-text': '&copy; 2025 Herramientas TDAH. Todas las herramientas son gratuitas y los datos se almacenan en tu navegador.'
   }
 };
+
+// expose translations for other modules
+if (typeof window !== 'undefined') {
+  window.translations = translations;
+}
 
 function applyTranslations(lang) {
   const dict = translations[lang] || translations.en;

--- a/index.html
+++ b/index.html
@@ -283,6 +283,10 @@
                         <input type="url" id="ics-url" placeholder="https://...ics">
                         <button id="load-ics-url-btn" class="btn">Load ICS URL</button>
                     </div>
+                    <div class="voice-options">
+                        <label><input type="checkbox" id="calendar-voice-enable"> <span data-i18n="calendar-voice-label">Voice alerts</span></label>
+                        <label><span data-i18n="calendar-voice-early-label">Minutes early:</span> <input type="number" id="calendar-voice-early" value="0" min="0" style="width:4rem"></label>
+                    </div>
                     <div id="calendar-view" class="calendar-events-list"></div>
                 </div>
             </section>


### PR DESCRIPTION
## Summary
- add voice reminder settings to calendar
- announce events at start or early using SpeechSynthesis
- expose translations globally and add new translation keys

## Testing
- `node routine.test.js` *(no output)*
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_68611a70f0c883219d756486648c9f9b