### PR TITLE
Add timestamp logging and Drive conflict resolution

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ADHD Tools Hub</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="timestamp-storage.js" defer></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="app.js" defer></script>
     <script src="cross-tool-interaction.js" defer></script>

--- a/timestamp-storage.js
+++ b/timestamp-storage.js
@@ -1,0 +1,29 @@
+(() => {
+  const LOG_KEY = 'adhd-storage-log';
+  const originalSetItem = Storage.prototype.setItem;
+
+  function updateLog(key) {
+    if (key === LOG_KEY) return;
+    let log;
+    try {
+      log = JSON.parse(localStorage.getItem(LOG_KEY)) || {};
+    } catch {
+      log = {};
+    }
+    log[key] = new Date().toISOString();
+    originalSetItem.call(localStorage, LOG_KEY, JSON.stringify(log));
+  }
+
+  Storage.prototype.setItem = function(key, value) {
+    updateLog(key);
+    originalSetItem.call(this, key, value);
+  };
+
+  window.getStorageLog = function() {
+    try {
+      return JSON.parse(localStorage.getItem(LOG_KEY)) || {};
+    } catch {
+      return {};
+    }
+  };
+})();

--- a/website_backend.ipynb
+++ b/website_backend.ipynb
@@ -1,85 +1,99 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "511d27e7",
-   "metadata": {},
-   "source": [
-    "# Website Backend Notebook\n",
-    "\n",
-    "This notebook is launched from the ADHD Tools website. It mounts your Google Drive and can read or write files based on parameters passed in the URL.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6ad85220",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from google.colab import drive, output\n",
-    "import os, json\n",
-    "\n",
-    "# Parse query parameters\n",
-    "params = json.loads(output.eval_js(\n",
-    "    \"JSON.stringify(Object.fromEntries(new URLSearchParams(window.location.search)))\"\n",
-    "))\n",
-    "print('Params:', params)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8f203cb7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "drive.mount('/content/drive')\n",
-    "DATA_DIR = '/content/drive/My Drive/ADHDtools'\n",
-    "os.makedirs(DATA_DIR, exist_ok=True)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c1f4c5d7",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def load_data(name, default=None):\n",
-    "    path = os.path.join(DATA_DIR, name)\n",
-    "    if os.path.exists(path):\n",
-    "        with open(path, 'r') as f:\n",
-    "            return json.load(f)\n",
-    "    return default if default is not None else {}\n",
-    "\n",
-    "\n",
-    "def save_data(name, data):\n",
-    "    with open(os.path.join(DATA_DIR, name), 'w') as f:\n",
-    "        json.dump(data, f)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "8cd1cb15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "filename = params.get('filename', 'webdata.json')\n",
-    "action = params.get('action', 'read')\n",
-    "\n",
-    "if action == 'write':\n",
-    "    data = params.get('data', {})\n",
-    "    save_data(filename, data)\n",
-    "    print(f'Saved to {filename}')\n",
-    "else:\n",
-    "    data = load_data(filename, {})\n",
-    "    print(f'Loaded from {filename}:', data)\n"
-   ]
-  }
- ],
- "metadata": {},
- "nbformat": 4,
- "nbformat_minor": 5
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "id": "511d27e7",
+      "metadata": {},
+      "source": [
+        "# Website Backend Notebook\n",
+        "\n",
+        "This notebook is launched from the ADHD Tools website. It mounts your Google Drive and can read or write files based on parameters passed in the URL.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6ad85220",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from google.colab import drive, output\n",
+        "import os, json\n",
+        "\n",
+        "# Parse query parameters\n",
+        "params = json.loads(output.eval_js(\n",
+        "    \"JSON.stringify(Object.fromEntries(new URLSearchParams(window.location.search)))\"\n",
+        "))\n",
+        "print('Params:', params)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8f203cb7",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "drive.mount('/content/drive')\n",
+        "DATA_DIR = '/content/drive/My Drive/ADHDtools'\n",
+        "os.makedirs(DATA_DIR, exist_ok=True)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "c1f4c5d7",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "def load_data(name, default=None):\n",
+        "    path = os.path.join(DATA_DIR, name)\n",
+        "    if os.path.exists(path):\n",
+        "        with open(path, 'r') as f:\n",
+        "            return json.load(f)\n",
+        "    return default if default is not None else {}\n",
+        "\n",
+        "def save_data(name, data):\n",
+        "    with open(os.path.join(DATA_DIR, name), 'w') as f:\n",
+        "        json.dump(data, f)\n",
+        "\n",
+        "def merge_by_timestamp(existing, incoming):\n",
+        "    log_key = 'adhd-storage-log'\n",
+        "    existing_log = existing.get(log_key, {})\n",
+        "    incoming_log = incoming.get(log_key, {})\n",
+        "    merged = {**existing, **incoming}\n",
+        "    merged_log = {**existing_log, **incoming_log}\n",
+        "    for key, ts in incoming_log.items():\n",
+        "        old_ts = existing_log.get(key)\n",
+        "        if not old_ts or ts > old_ts:\n",
+        "            merged[key] = incoming.get(key)\n",
+        "    merged[log_key] = merged_log\n",
+        "    return merged\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "8cd1cb15",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "filename = params.get('filename', 'webdata.json')\n",
+        "action = params.get('action', 'read')\n",
+        "\n",
+        "if action == 'write':\n",
+        "    data = params.get('data', {})\n",
+        "    existing = load_data(filename, {})\n",
+        "    merged = merge_by_timestamp(existing, data)\n",
+        "    save_data(filename, merged)\n",
+        "    print(f'Saved to {filename}')\n",
+        "else:\n",
+        "    data = load_data(filename, {})\n",
+        "    print(f'Loaded from {filename}:', data)\n"
+      ]
+    }
+  ],
+  "metadata": {},
+  "nbformat": 4,
+  "nbformat_minor": 5
 }


### PR DESCRIPTION
## Summary
- track localStorage updates and store timestamps
- load new timestamp handler before other scripts
- merge Drive data by timestamp in backend

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6885ba6805f0832185dfeda861fd23f2