### PR TITLE
Add Gemini API support for task breakdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+api-key.js

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ All data is stored locally in your browser. Nothing is sent to any server, ensur
 
 If you have suggestions or feedback, please let me know!
 
+## Gemini API Setup
+
+Some tools can use Google Gemini to suggest tasks or categorize items. To enable these features you need a personal API key.
+
+1. **Visit [Google AI Studio](https://aistudio.google.com/)** and sign in with your Google account.
+2. **Create a project** if prompted. A name like `ADHD-Tools-Project` works well.
+3. **Generate an API key** and copy the long string shown.
+4. **Store it securely** – treat this key like a password and never commit it to Git.
+5. **Add the key to your browser** by running the following in the developer console:
+
+   ```js
+   localStorage.setItem('geminiApiKey', 'PASTE_YOUR_KEY_HERE');
+   ```
+
+   The key is saved only in your browser.
+
 ## Contributing
 
 If you'd like to contribute, please follow these steps:

--- a/gemini.js
+++ b/gemini.js
@@ -1,0 +1,32 @@
+// gemini.js - helper for Google Gemini API
+// Reads API key from localStorage under 'geminiApiKey'
+// Exposes global function callGemini(prompt)
+
+async function callGemini(prompt) {
+  const apiKey = localStorage.getItem('geminiApiKey');
+  if (!apiKey) {
+    throw new Error('Gemini API key not found. Set it in localStorage with key "geminiApiKey".');
+  }
+
+  const url = `https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent?key=${apiKey}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      contents: [{ parts: [{ text: prompt }]}]
+    })
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(`Gemini API error: ${err}`);
+  }
+
+  const data = await response.json();
+  return data.candidates?.[0]?.content?.parts?.[0]?.text?.trim();
+}
+
+window.callGemini = callGemini;

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="app.js" defer></script>
     <script src="data-manager.js" defer></script>
+    <script src="gemini.js" defer></script>
     <script src="pomodoro.js" defer></script>
     <script src="eisenhower.js" defer></script>
     <script src="day-planner.js" defer></script>
@@ -383,6 +384,7 @@
                         <div class="project-input">
                             <input type="text" id="project-input" placeholder="New project name...">
                             <button id="add-project" class="btn">Add Project</button>
+                            <button id="ai-breakdown" class="btn">✨ Break it Down for Me</button>
                         </div>
                         <ul id="project-list" class="project-list">
                             <!-- Projects will be added here by JavaScript -->

--- a/task-breakdown.js
+++ b/task-breakdown.js
@@ -7,6 +7,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const mainInput = document.getElementById('project-input');
   const addMainBtn = document.getElementById('add-project');
+  const aiBtn = document.getElementById('ai-breakdown');
   const listContainer = document.getElementById('project-list');
   const STORAGE_KEY = 'adhd-breakdown-tasks';
 
@@ -134,6 +135,31 @@ document.addEventListener('DOMContentLoaded', () => {
   // Bind main add
   addMainBtn.addEventListener('click', addMain);
   mainInput.addEventListener('keypress', e => { if (e.key === 'Enter') addMain(); });
+
+  // AI breakdown generation
+  aiBtn.addEventListener('click', async () => {
+    const task = mainInput.value.trim();
+    if (!task) return;
+    aiBtn.disabled = true;
+    const originalText = aiBtn.textContent;
+    aiBtn.textContent = 'Generating...';
+    try {
+      const prompt = `Break down the task '${task}' into a list of simple sub-tasks. Put each sub-task on a new line.`;
+      const aiText = await callGemini(prompt);
+      if (!aiText) throw new Error('No response');
+      const steps = aiText.split('\n').map(t => t.replace(/^[*-]\s*/, '').trim()).filter(Boolean);
+      const newNode = { text: task, completed: false, subtasks: steps.map(s => ({ text: s, completed: false, subtasks: [] })) };
+      tree.push(newNode);
+      saveTree();
+      renderTree();
+      mainInput.value = '';
+    } catch (err) {
+      alert(err.message);
+    } finally {
+      aiBtn.disabled = false;
+      aiBtn.textContent = originalText;
+    }
+  });
 
   // Initial render
   renderTree();


### PR DESCRIPTION
## Summary
- add `gemini.js` helper that calls Google's Gemini API using an API key from localStorage
- extend Task Breakdown with an "✨ Break it Down for Me" button that generates subtasks via Gemini
- document how to obtain and store a Gemini API key

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9121c58f483219663e6758c3b30b4