### PR TITLE
Enhance pomodoro timer UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,9 @@
                     
                     <div class="session-counter">
                         <span>Sessions completed: <span id="session-count">0</span></span>
+                        <span> (Long break in <span id="sessions-until-long">0</span>)</span>
                     </div>
+                    <div id="mode-change-message" class="mode-change-message"></div>
                     
                     <details class="pomodoro-settings-collapsible">
                         <summary>Settings <i class="fas fa-cog"></i></summary>
@@ -179,6 +181,7 @@
                                 <option value="digital">Digital</option>
                                 <option value="none">None</option>
                             </select>
+                            <button id="preview-sound" class="btn btn-secondary" type="button">Preview</button>
                         </div>
                         <button id="save-settings" class="btn">Save Settings</button>
                         </div>

--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,7 @@ footer {
 .timer-label { font-size: 1.2rem; color: var(--on-primary); text-transform: uppercase; letter-spacing: 2px; }
 .timer-controls { display: flex; justify-content: center; gap: 1rem; margin-bottom: 2rem; }
 .session-counter { text-align: center; margin-bottom: 2rem; font-size: 1.2rem; }
+.mode-change-message { text-align: center; font-size: 1.1rem; margin-bottom: 1rem; }
 
 /* Collapsible Pomodoro Settings */
 .pomodoro-settings-collapsible {


### PR DESCRIPTION
## Summary
- show remaining sessions until long break and display messages on mode changes
- allow previewing multiple notification sounds
- re-enable start button after saving new settings

## Testing
- `npm install jsdom`
- `node routine.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b980cd909c8321aaf7b15af18e9b77