### PR TITLE
feat: expand day planner functionality

### DIFF
--- a/day-planner.js
+++ b/day-planner.js
@@ -16,6 +16,11 @@ document.addEventListener('DOMContentLoaded', function() {
     const eventForm = document.getElementById('event-form');
     const eventTitleInput = document.getElementById('event-title');
     const eventTimeSelect = document.getElementById('event-time');
+    const eventTaskSelect = document.getElementById('event-task');
+    const eventDurationInput = document.getElementById('event-duration');
+    const eventModalTitle = document.getElementById('event-modal-title');
+
+    let editingTaskId = null;
 
     let currentDate = new Date();
 
@@ -42,23 +47,34 @@ document.addEventListener('DOMContentLoaded', function() {
 
                 const eventContent = document.createElement('div');
                 eventContent.className = 'event-content';
-                
+
                 const tasksInBlock = todaysTasks.filter(t => t.plannerDate.startsWith(timeKey.slice(0, 13)));
-                
+
                 tasksInBlock.forEach(task => {
                     const eventDiv = document.createElement('div');
                     eventDiv.className = 'event';
                     eventDiv.textContent = task.text;
-                    if (task.isCompleted) {
-                        eventDiv.style.textDecoration = 'line-through';
-                    }
-                    eventDiv.addEventListener('click', () => {
-                        // Simple toggle completion
-                        window.DataManager.updateTask(task.id, { isCompleted: !task.isCompleted });
+                    eventDiv.style.height = `calc(${task.duration || 60} * var(--minute-height))`;
+
+                    eventDiv.addEventListener('click', () => openModal(task));
+
+                    const del = document.createElement('span');
+                    del.className = 'delete-event';
+                    del.textContent = '×';
+                    del.addEventListener('click', e => {
+                        e.stopPropagation();
+                        window.DataManager.updateTask(task.id, { plannerDate: null });
                     });
+                    eventDiv.appendChild(del);
+
+                    const handle = document.createElement('div');
+                    handle.className = 'resize-handle';
+                    handle.addEventListener('mousedown', e => startResize(e, task, eventDiv));
+                    eventDiv.appendChild(handle);
+
                     eventContent.appendChild(eventDiv);
                 });
-                
+
                 timeBlock.appendChild(eventContent);
                 timeBlocksContainer.appendChild(timeBlock);
             }
@@ -81,34 +97,88 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     }
 
-    function openModal() {
+    function populateTaskOptions() {
+        eventTaskSelect.innerHTML = '<option value="">-- New Event --</option>';
+        const tasks = window.DataManager.getTasks().filter(t => !t.plannerDate);
+        tasks.forEach(t => {
+            const opt = document.createElement('option');
+            opt.value = t.id;
+            opt.textContent = t.text;
+            eventTaskSelect.appendChild(opt);
+        });
+    }
+
+    function openModal(task) {
         eventModal.style.display = 'block';
-        eventTitleInput.value = '';
         populateTimeOptions();
+        populateTaskOptions();
+        if (task) {
+            editingTaskId = task.id;
+            eventModalTitle.textContent = 'Edit Event';
+            eventTitleInput.value = task.text;
+            eventTimeSelect.value = task.plannerDate.slice(11, 16);
+            eventDurationInput.value = task.duration || 60;
+            eventTitleInput.disabled = false;
+            eventTaskSelect.value = '';
+            eventTaskSelect.disabled = true;
+        } else {
+            editingTaskId = null;
+            eventModalTitle.textContent = 'Add Event';
+            eventTitleInput.value = '';
+            eventTimeSelect.selectedIndex = 0;
+            eventDurationInput.value = 60;
+            eventTitleInput.disabled = false;
+            eventTaskSelect.value = '';
+            eventTaskSelect.disabled = false;
+        }
     }
 
     function closeModal() {
         eventModal.style.display = 'none';
     }
 
-    addEventBtn.addEventListener('click', openModal);
+    addEventBtn.addEventListener('click', () => openModal());
     closeButton.addEventListener('click', closeModal);
     window.addEventListener('click', e => { if (e.target === eventModal) closeModal(); });
 
+    eventTaskSelect.addEventListener('change', () => {
+        const id = eventTaskSelect.value;
+        if (id) {
+            const task = window.DataManager.getTask(id);
+            eventTitleInput.value = task.text;
+            eventTitleInput.disabled = true;
+            eventDurationInput.value = task.duration || 60;
+        } else {
+            eventTitleInput.disabled = false;
+            eventTitleInput.value = '';
+        }
+    });
+
     eventForm.addEventListener('submit', e => {
         e.preventDefault();
-        const title = eventTitleInput.value.trim();
-        if (!title) return;
-        
         const time = eventTimeSelect.value;
+        const duration = parseInt(eventDurationInput.value, 10) || 60;
         const plannerDateTime = `${currentDate.toISOString().slice(0, 10)}T${time}`;
 
-        window.DataManager.addTask({
-            text: title,
-            originalTool: 'DayPlanner',
-            plannerDate: plannerDateTime,
-        });
-        
+        if (editingTaskId) {
+            const title = eventTitleInput.value.trim();
+            window.DataManager.updateTask(editingTaskId, { text: title, plannerDate: plannerDateTime, duration });
+        } else {
+            const selectedTaskId = eventTaskSelect.value;
+            if (selectedTaskId) {
+                window.DataManager.updateTask(selectedTaskId, { plannerDate: plannerDateTime, duration });
+            } else {
+                const title = eventTitleInput.value.trim();
+                if (!title) return;
+                window.DataManager.addTask({
+                    text: title,
+                    originalTool: 'DayPlanner',
+                    plannerDate: plannerDateTime,
+                    duration,
+                });
+            }
+        }
+
         closeModal();
     });
 
@@ -123,8 +193,74 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
-    window.EventBus.addEventListener('dataChanged', renderDayPlanner);
+    function startResize(e, task, eventDiv) {
+        e.preventDefault();
+        const startY = e.clientY;
+        const startDuration = task.duration || 60;
+        const minuteHeight = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--minute-height')) || 2;
+        function onMove(ev) {
+            const diff = ev.clientY - startY;
+            const minutes = Math.max(15, startDuration + Math.round(diff / minuteHeight / 15) * 15);
+            eventDiv.style.height = `calc(${minutes} * var(--minute-height))`;
+        }
+        function onUp(ev) {
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onUp);
+            const diff = ev.clientY - startY;
+            const minutes = Math.max(15, startDuration + Math.round(diff / minuteHeight / 15) * 15);
+            window.DataManager.updateTask(task.id, { duration: minutes });
+        }
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+    }
+
+    // Zoom handling
+    let zoomLevel = 1;
+    function applyZoom() {
+        document.documentElement.style.setProperty('--minute-height', `${2 * zoomLevel}px`);
+    }
+    applyZoom();
+
+    timeBlocksContainer.addEventListener('wheel', e => {
+        if (e.ctrlKey || Math.abs(e.deltaY) > Math.abs(e.deltaX)) {
+            e.preventDefault();
+            const factor = e.deltaY > 0 ? 0.9 : 1.1;
+            zoomLevel = Math.min(4, Math.max(0.5, zoomLevel * factor));
+            applyZoom();
+        }
+    }, { passive: false });
+
+    let pinchDist = null;
+    timeBlocksContainer.addEventListener('touchmove', e => {
+        if (e.touches.length === 2) {
+            e.preventDefault();
+            const dist = Math.hypot(
+                e.touches[0].clientX - e.touches[1].clientX,
+                e.touches[0].clientY - e.touches[1].clientY
+            );
+            if (pinchDist) {
+                const factor = dist / pinchDist;
+                zoomLevel = Math.min(4, Math.max(0.5, zoomLevel * factor));
+                applyZoom();
+            }
+            pinchDist = dist;
+        }
+    }, { passive: false });
+    timeBlocksContainer.addEventListener('touchend', () => pinchDist = null);
+
+    function scrollToCurrent() {
+        const now = new Date();
+        const hoursFromStart = now.getHours();
+        const minuteHeight = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--minute-height')) || 2;
+        timeBlocksContainer.scrollTop = hoursFromStart * 60 * minuteHeight;
+    }
+
+    window.EventBus.addEventListener('dataChanged', () => {
+        renderDayPlanner();
+        scrollToCurrent();
+    });
 
     renderDayPlanner();
+    scrollToCurrent();
 });
 

--- a/index.html
+++ b/index.html
@@ -257,16 +257,22 @@
                     </div>
                 </div>
 
-                <!-- Modal for Adding an Event -->
+                <!-- Modal for Adding/Editing an Event -->
                 <div id="event-modal" class="modal">
                   <div class="modal-content">
                     <span class="close-button">&times;</span>
-                    <h3>Add Event</h3>
+                    <h3 id="event-modal-title">Add Event</h3>
                     <form id="event-form">
+                      <label for="event-task">Import Task:</label>
+                      <select id="event-task">
+                        <option value="">-- New Event --</option>
+                      </select>
                       <label for="event-title">Title:</label>
                       <input type="text" id="event-title" required>
-                      <label for="event-time">Time:</label>
+                      <label for="event-time">Start Time:</label>
                       <select id="event-time"></select>
+                      <label for="event-duration">Duration (minutes):</label>
+                      <input type="number" id="event-duration" min="15" step="15" value="60" required>
                       <button type="submit" class="btn">Save Event</button>
                     </form>
                   </div>

--- a/styles.css
+++ b/styles.css
@@ -684,6 +684,7 @@ footer {
     border: 1px solid #ddd;
     border-radius: var(--border-radius);
     overflow-y: auto;
+    height: calc(4 * 60 * var(--minute-height));
     max-height: 80vh;
 }
 
@@ -714,15 +715,20 @@ footer {
     width: calc(100% - 80px);
 }
 
+
+:root {
+    --minute-height: 2px;
+}
+
 .time-block {
     padding: 0.5rem;
-    min-height: 80px;
-    border-right: 1px solid #eee;
+    height: calc(60 * var(--minute-height));
+    border-bottom: 1px solid #eee;
     position: relative;
 }
 
 .time-block:last-child {
-    border-right: none;
+    border-bottom: none;
 }
 
 .time-label {
@@ -732,7 +738,8 @@ footer {
 }
 
 .event-content {
-    min-height: 50px;
+    position: relative;
+    height: calc(60 * var(--minute-height));
     font-size: 0.9rem;
 }
 
@@ -751,8 +758,29 @@ footer {
     color: var(--on-primary);
     padding: 0.25rem 0.5rem;
     border-radius: 4px;
-    margin-bottom: 0.25rem;
     font-size: 0.85rem;
+    position: absolute;
+    left: 0;
+    right: 0;
+    overflow: hidden;
+}
+
+.event .delete-event {
+    position: absolute;
+    top: 2px;
+    right: 4px;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.event .resize-handle {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 6px;
+    cursor: s-resize;
+    background-color: rgba(0,0,0,0.2);
 }
 
 /* Modal styles */


### PR DESCRIPTION
## Summary
- allow editing, deleting, and resizing individual planner events
- support importing tasks, custom durations, and zoomable four-hour view

## Testing
- `node routine.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9bc9de27c8321b41ba7b621cd6cda