### PR TITLE
Add manual calendar events with drag-drop and conditional Google Calendar loading

### DIFF
--- a/script-loader.js
+++ b/script-loader.js
@@ -1,12 +1,16 @@
 // Update index.html to include the new JavaScript files
 document.addEventListener('DOMContentLoaded', function() {
-    // Load Google Calendar integration only if credentials are provided
+    // Load Google Calendar integration only if both credentials are provided.
     const clientId = localStorage.getItem('gcalClientId');
     const apiKey = localStorage.getItem('gcalApiKey');
-    if (clientId && apiKey && !document.querySelector('script[src="calendar-integration.js"]')) {
-        const calendarScript = document.createElement('script');
-        calendarScript.src = 'calendar-integration.js';
-        document.body.appendChild(calendarScript);
+    if (clientId && apiKey) {
+        if (!document.querySelector('script[src="calendar-integration.js"]')) {
+            const calendarScript = document.createElement('script');
+            calendarScript.src = 'calendar-integration.js';
+            document.body.appendChild(calendarScript);
+        }
+    } else {
+        console.log('Google Calendar integration skipped: missing credentials');
     }
 
     // Add celebration container for rewards


### PR DESCRIPTION
## Summary
- enable event creation on calendar by double-clicking a date
- support dragging events between days; persist changes in local storage
- load Google Calendar integration only when API keys are stored

## Testing
- `node routine.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9bdbf408883218b479c0a6573f37b