### PR TITLE
Fix task manager duplication and cross-tool integration

### DIFF
--- a/day-planner.js
+++ b/day-planner.js
@@ -260,6 +260,36 @@ document.addEventListener('DOMContentLoaded', function() {
         scrollToCurrent();
     });
 
+    // Handle tasks sent from other tools
+    window.EventBus.addEventListener('ef-receiveTaskFor-DayPlanner', handleReceivedTaskForDayPlanner);
+
+    function handleReceivedTaskForDayPlanner(event) {
+        const task = event.detail;
+        if (!task || !task.text) {
+            console.warn('Day Planner received invalid task:', task);
+            return;
+        }
+
+        // Ask user for time and duration to schedule the task
+        const time = prompt(`Enter time (HH:MM) for '${task.text}' in the Day Planner:`, '09:00');
+        if (time === null) return; // user cancelled
+        const durationStr = prompt(`Enter duration in minutes:`, task.duration || '60');
+        if (durationStr === null) return;
+        const duration = parseInt(durationStr, 10) || 60;
+
+        const plannerDateTime = `${currentDate.toISOString().slice(0,10)}T${time}`;
+        window.DataManager.addTask({
+            text: task.text,
+            originalTool: task.originalTool || 'TaskManager',
+            priority: task.priority || 'medium',
+            category: task.category || 'other',
+            plannerDate: plannerDateTime,
+            duration
+        });
+        renderDayPlanner();
+        alert(`Task '${task.text}' added to Day Planner.`);
+    }
+
     renderDayPlanner();
     scrollToCurrent();
 });

--- a/task-manager.js
+++ b/task-manager.js
@@ -90,8 +90,9 @@ document.addEventListener('DOMContentLoaded', () => {
       prio.textContent = task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
       const cat = document.createElement('span');
       cat.className = 'task-category';
-      cat.textContent = task.category;
-      meta.append(prio, cat);
+      cat.textContent = task.category.charAt(0).toUpperCase() + task.category.slice(1);
+      // Add a separator so the priority and category don't run together
+      meta.append(prio, document.createTextNode(' | '), cat);
 
       // Actions
       const actions = document.createElement('div');
@@ -269,7 +270,10 @@ document.addEventListener('DOMContentLoaded', () => {
       createdAt: new Date().toISOString()
     };
     tasks.push(newTask);
+    // Clear inputs so values don't concatenate on subsequent entries
     inputEl.value = '';
+    prioritySelectEl.selectedIndex = 1; // Medium
+    categorySelectEl.selectedIndex = Array.from(categorySelectEl.options).findIndex(opt => opt.value === 'other');
     saveTasks();
   }
 


### PR DESCRIPTION
## Summary
- Separate priority and category labels and reset task fields after creating a task
- Add Day Planner listener so tasks sent from Task Manager can be scheduled with prompts

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node routine.test.js` *(outputs: Routine functions not available for testing. Load routine.js first or structure for testability.)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bebb86308321873fb41f6fb4ffda