### PR TITLE
Enable cross-tool task imports and shared event bus

### DIFF
--- a/cross-tool-interaction.js
+++ b/cross-tool-interaction.js
@@ -1,8 +1,8 @@
 // cross-tool-interaction.js
 
 (() => {
-  // EventBus for cross-tool communication
-  const bus = new EventTarget();
+  // EventBus for cross-tool communication. Re-use existing bus if available
+  const bus = window.EventBus || new EventTarget();
   window.EventBus = bus;
 
   // LocalStorage keys

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
     <script src="app.js" defer></script>
     <script src="data-manager.js" defer></script>
+    <script src="cross-tool-interaction.js" defer></script>
     <script src="gemini.js" defer></script>
     <script src="api-settings.js" defer></script>
     <script src="pomodoro.js" defer></script>
@@ -329,6 +330,9 @@
                             </select>
                         </div>
                         <button id="add-task-btn" class="btn">Add Task</button>
+                        <select id="task-import-select">
+                            <option value="">--Import Task--</option>
+                        </select>
                     </div>
                     
                     <details class="task-filters-collapsible">


### PR DESCRIPTION
## Summary
- Load cross-tool interaction bus and reuse existing EventBus to coordinate tools
- Sync Task Manager with central DataManager and add import dropdown for tasks from other modules
- Allow Task Manager to receive tasks via EventBus and broadcast additions/completions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b9da4b0334832183c784d769358e5d