### PR TITLE
Integrate day planner events into calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,7 @@
                         <button data-view="month" class="calendar-view-btn btn">Month</button>
                         <button id="calendar-next-btn" class="btn">&gt;</button>
                     </div>
+                    <div id="calendar-header" class="calendar-header"></div>
                     <button id="import-ics-btn" class="btn">Import ICS</button>
                     <input type="file" id="ics-file-input" accept=".ics" style="display:none">
                     <div class="ics-url-input">

--- a/styles.css
+++ b/styles.css
@@ -986,6 +986,11 @@ footer {
     background-color: var(--primary-color);
     color: #fff;
 }
+.calendar-header {
+    text-align: center;
+    font-weight: bold;
+    margin: 0.5rem 0;
+}
 .calendar-table {
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
## Summary
- Display current period in calendar via new header and update it when navigating.
- Merge Day Planner tasks into calendar views and re-render on data changes.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68baca4102d883218b4b14b744dd0d0f