### PR TITLE
fix: stabilize task manager interactions

### DIFF
--- a/cross-tool-interaction.js
+++ b/cross-tool-interaction.js
@@ -144,7 +144,7 @@
      * @param {object} taskObject - The task object, ideally adhering to StandardizedTask structure.
      * @param {string} targetTool - The identifier of the target tool (e.g., 'DayPlanner').
      */
-    sendTaskToTool: function(taskObject, targetTool) {
+    sendTaskToTool: function(taskObject, targetTool, options = {}) {
       if (!taskObject || typeof taskObject !== 'object') {
         console.error('CrossTool.sendTaskToTool: taskObject is invalid.', taskObject);
         return;
@@ -154,10 +154,14 @@
         return;
       }
 
+      const { openTool: open = true } = options;
+
       const eventName = `ef-receiveTaskFor-${targetTool}`;
       console.log(`CrossTool: Dispatching event '${eventName}' with task:`, taskObject);
       this.bus.dispatchEvent(new CustomEvent(eventName, { detail: taskObject }));
-      this.openTool(targetTool);
+      if (open) {
+        this.openTool(targetTool);
+      }
     },
 
     /**
@@ -165,12 +169,12 @@
      * @param {Array<object>} tasks - array of task objects
      * @param {string} targetTool - identifier of the target tool
      */
-    sendTasksToTool: function(tasks, targetTool) {
+    sendTasksToTool: function(tasks, targetTool, options) {
       if (!Array.isArray(tasks)) {
         console.error('CrossTool.sendTasksToTool: tasks must be an array');
         return;
       }
-      tasks.forEach(task => this.sendTaskToTool(task, targetTool));
+      tasks.forEach(task => this.sendTaskToTool(task, targetTool, options));
     }
   };
 })();

--- a/task-manager.js
+++ b/task-manager.js
@@ -24,6 +24,27 @@ document.addEventListener('DOMContentLoaded', () => {
   // Local cache of tasks from DataManager
   let tasks = DataManager ? DataManager.getTasks() : [];
 
+  function sanitizeText(str) {
+    return str
+      .replace(/(\b\w+\b)(\s+\1)+/gi, '$1') // remove consecutive duplicate words
+      .replace(/(\b\w+\b)\1+/gi, '$1') // remove directly concatenated duplicates
+      .replace(/\s+/g, ' ') // collapse whitespace
+      .trim();
+  }
+
+  function createMeta(priority, category) {
+    const meta = document.createElement('div');
+    meta.className = 'task-meta';
+    const prio = document.createElement('span');
+    prio.className = 'task-priority';
+    prio.textContent = priority.charAt(0).toUpperCase() + priority.slice(1);
+    const cat = document.createElement('span');
+    cat.className = 'task-category';
+    cat.textContent = category.charAt(0).toUpperCase() + category.slice(1);
+    meta.append(prio, document.createTextNode(' | '), cat);
+    return meta;
+  }
+
   function refreshTasks() {
     tasks = DataManager.getTasks();
   }
@@ -66,16 +87,7 @@ document.addEventListener('DOMContentLoaded', () => {
       text.textContent = task.text;
 
       // Meta container
-      const meta = document.createElement('div');
-      meta.className = 'task-meta';
-      const prio = document.createElement('span');
-      prio.className = 'task-priority';
-      prio.textContent = task.priority.charAt(0).toUpperCase() + task.priority.slice(1);
-      const cat = document.createElement('span');
-      cat.className = 'task-category';
-      cat.textContent = task.category.charAt(0).toUpperCase() + task.category.slice(1);
-      // Add a separator so the priority and category don't run together
-      meta.append(prio, document.createTextNode(' | '), cat);
+      const meta = createMeta(task.priority, task.category);
 
       // Actions
       const actions = document.createElement('div');
@@ -120,7 +132,7 @@ document.addEventListener('DOMContentLoaded', () => {
         saveBtn.textContent = 'Save';
         saveBtn.className = 'edit-task-save-btn';
         saveBtn.addEventListener('click', () => {
-          const newText = textInput.value.trim();
+          const newText = sanitizeText(textInput.value);
           if (newText) {
             task.text = newText;
             task.priority = prioritySelect.value;
@@ -183,7 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
           notes: null,
           subTasks: [] 
         };
-        window.CrossTool.sendTaskToTool(standardizedTask, 'DayPlanner');
+        window.CrossTool.sendTaskToTool(standardizedTask, 'DayPlanner', { openTool: false });
         alert(`Task "${task.text}" sent to Day Planner.`);
       });
 
@@ -203,7 +215,7 @@ document.addEventListener('DOMContentLoaded', () => {
           notes: null,
           subTasks: []
         };
-        window.CrossTool.sendTaskToTool(standardizedTask, 'TaskBreakdown');
+        window.CrossTool.sendTaskToTool(standardizedTask, 'TaskBreakdown', { openTool: false });
         alert(`Task "${task.text}" sent to Task Breakdown.`);
       });
 
@@ -225,7 +237,7 @@ document.addEventListener('DOMContentLoaded', () => {
           notes: null,
           subTasks: []
         };
-        window.CrossTool.sendTaskToTool(standardizedTask, 'Routine');
+        window.CrossTool.sendTaskToTool(standardizedTask, 'Routine', { openTool: false });
         alert(`Task "${task.text}" sent to Routine.`);
       });
 
@@ -319,7 +331,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   // Add new task
   function addTask() {
-    const text = inputEl.value.trim();
+    const text = sanitizeText(inputEl.value);
     if (!text) return;
 
     const newTask = DataManager.addTask({


### PR DESCRIPTION
## Summary
- clean task text and keep priority/category labels separated
- avoid scrolling to top when sending tasks to other tools
- sanitize text input to reduce duplicates when adding or editing

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bacab30a2c832194bf4e5b66051d33