### PR TITLE
Add habit export and longest streak tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,6 +441,9 @@
                             <input type="text" id="habit-input" placeholder="New habit...">
                             <button id="add-habit" class="btn">Add Habit</button>
                         </div>
+                        <div class="habit-actions">
+                            <button id="export-habits" class="btn btn-secondary">Export Data</button>
+                        </div>
                         <div class="habit-list" id="habit-stats">
                             <!-- Habits will be rendered by JavaScript -->
                         </div>

--- a/styles.css
+++ b/styles.css
@@ -439,6 +439,12 @@ footer {
     flex: 1;
 }
 
+.habit-actions {
+    margin-bottom: 1rem;
+    display: flex;
+    justify-content: flex-end;
+}
+
 .habit-list .habit-item {
     margin-bottom: 1rem;
     border: 1px solid #eee;


### PR DESCRIPTION
## Summary
- Show current and longest streaks for each habit
- Add export button to download habit and log data as JSON
- Fix habit calendar click handling for multiple habits

## Testing
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_68bacb36fc388321af88a9e34ea6ea47