### PR TITLE
feat: integrate gemini auto-planning into day planner

### DIFF
--- a/index.html
+++ b/index.html
@@ -251,6 +251,9 @@
                             <button id="clear-events-btn" class="btn btn-secondary">
                                 <i class="fas fa-trash"></i> <span class="btn-text">Clear All</span>
                             </button>
+                            <button id="ai-plan-day-btn" class="btn btn-secondary">
+                                <i class="fas fa-magic"></i> <span class="btn-text">AI Plan</span>
+                            </button>
                         </div>
                     </div>
 


### PR DESCRIPTION
## Summary
- add AI Plan button for quick interaction with the day planner
- use Gemini to schedule tasks from task breakdown and Eisenhower tools while respecting calendar events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bae0cd30bc8321a99696f203c83091