### PR TITLE
Move Google Calendar credential input to calendar page

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,13 @@ That's it! The Gemini-powered features in ADHD Tools should now be enabled.
 
 ## Optional Google Calendar Integration
 
-If you want to connect the Day Planner to your Google Calendar, follow these steps:
+To connect the Day Planner to your Google Calendar:
 
 1. **Create API credentials** – In the [Google Cloud Console](https://console.cloud.google.com/), enable the *Google Calendar API* and create an **API key** and an **OAuth client ID** (type Web application).
-2. **Store credentials in the browser** – Open the site and run the following in the browser console:
-   ```javascript
-   localStorage.setItem('gcalClientId', 'YOUR_CLIENT_ID');
-   localStorage.setItem('gcalApiKey', 'YOUR_API_KEY');
-   ```
-3. **Reload and connect** – Refresh the page and click **Connect Google Calendar**. After authorizing, events from the current day in your primary calendar are saved locally and shown automatically in the Day Planner.
+2. **Enter credentials in the Calendar tool** – Open the Calendar page and use the **Google Calendar API** box at the top to save your Client ID and API key.
+3. **Connect your calendar** – After saving, click **Connect Google Calendar** in the Day Planner or Task Manager and authorize access. Events from the current day in your primary calendar are saved locally and shown automatically.
 
-Your credentials remain in your browser only. Remove them anytime with `localStorage.removeItem('gcalClientId')` and `localStorage.removeItem('gcalApiKey')`.
+Your credentials remain in your browser only. Use the **Clear** button in the Calendar settings to remove them at any time.
 
 ## Deprecated Backend Notebook
 

--- a/api-settings.js
+++ b/api-settings.js
@@ -1,5 +1,5 @@
 // api-settings.js - UI for managing API credentials
-// Allows saving/clearing Gemini and Google Calendar keys in localStorage
+// Allows saving/clearing Gemini API key in localStorage
 
 document.addEventListener('DOMContentLoaded', () => {
   const aboutSection = document.getElementById('about');
@@ -15,15 +15,6 @@ document.addEventListener('DOMContentLoaded', () => {
       <button id="save-gemini-key" class="btn btn-primary">Save</button>
       <button id="clear-gemini-key" class="btn btn-secondary">Clear</button>
       <span id="gemini-key-status" class="status"></span>
-    </div>
-    <div class="api-setting">
-      <label for="gcal-client-id-input">Google Calendar Client ID:</label>
-      <input type="text" id="gcal-client-id-input" placeholder="Enter Client ID" />
-      <label for="gcal-api-key-input">Google Calendar API Key:</label>
-      <input type="password" id="gcal-api-key-input" placeholder="Enter API Key" />
-      <button id="save-gcal-keys" class="btn btn-primary">Save</button>
-      <button id="clear-gcal-keys" class="btn btn-secondary">Clear</button>
-      <span id="gcal-key-status" class="status"></span>
     </div>
   `;
   aboutSection.appendChild(container);
@@ -49,34 +40,6 @@ document.addEventListener('DOMContentLoaded', () => {
   container.querySelector('#clear-gemini-key').addEventListener('click', () => {
     localStorage.removeItem('geminiApiKey');
     geminiStatus.textContent = 'Key cleared';
-  });
-
-  // Google Calendar key handlers
-  const gcalClientInput = container.querySelector('#gcal-client-id-input');
-  const gcalApiInput = container.querySelector('#gcal-api-key-input');
-  const gcalStatus = container.querySelector('#gcal-key-status');
-  if (localStorage.getItem('gcalClientId') && localStorage.getItem('gcalApiKey')) {
-    gcalStatus.textContent = 'Keys saved';
-  }
-
-  container.querySelector('#save-gcal-keys').addEventListener('click', () => {
-    const clientId = gcalClientInput.value.trim();
-    const apiKey = gcalApiInput.value.trim();
-    if (!clientId || !apiKey) {
-      gcalStatus.textContent = 'Missing fields';
-      return;
-    }
-    localStorage.setItem('gcalClientId', clientId);
-    localStorage.setItem('gcalApiKey', apiKey);
-    gcalClientInput.value = '';
-    gcalApiInput.value = '';
-    gcalStatus.textContent = 'Keys saved';
-  });
-
-  container.querySelector('#clear-gcal-keys').addEventListener('click', () => {
-    localStorage.removeItem('gcalClientId');
-    localStorage.removeItem('gcalApiKey');
-    gcalStatus.textContent = 'Keys cleared';
   });
 });
 

--- a/calendar-settings.js
+++ b/calendar-settings.js
@@ -1,0 +1,56 @@
+// calendar-settings.js - Manage Google Calendar API credentials on the calendar page
+
+document.addEventListener('DOMContentLoaded', () => {
+  const calendarSection = document.getElementById('calendar');
+  if (!calendarSection) return;
+
+  const container = document.createElement('div');
+  container.id = 'gcal-settings';
+  container.innerHTML = `
+    <h3>Google Calendar API</h3>
+    <p>Enter your Google Calendar Client ID and API Key to enable calendar sync.</p>
+    <div class="api-setting">
+      <label for="gcal-client-id-input">Client ID:</label>
+      <input type="text" id="gcal-client-id-input" placeholder="Enter Client ID" />
+    </div>
+    <div class="api-setting">
+      <label for="gcal-api-key-input">API Key:</label>
+      <input type="password" id="gcal-api-key-input" placeholder="Enter API Key" />
+    </div>
+    <button id="save-gcal-keys" class="btn btn-primary">Save</button>
+    <button id="clear-gcal-keys" class="btn btn-secondary">Clear</button>
+    <span id="gcal-key-status" class="status"></span>
+  `;
+
+  const firstChild = calendarSection.querySelector('.calendar-container');
+  calendarSection.insertBefore(container, firstChild);
+
+  const clientInput = container.querySelector('#gcal-client-id-input');
+  const apiInput = container.querySelector('#gcal-api-key-input');
+  const status = container.querySelector('#gcal-key-status');
+
+  if (localStorage.getItem('gcalClientId') && localStorage.getItem('gcalApiKey')) {
+    status.textContent = 'Keys saved';
+  }
+
+  container.querySelector('#save-gcal-keys').addEventListener('click', () => {
+    const clientId = clientInput.value.trim();
+    const apiKey = apiInput.value.trim();
+    if (!clientId || !apiKey) {
+      status.textContent = 'Missing fields';
+      return;
+    }
+    localStorage.setItem('gcalClientId', clientId);
+    localStorage.setItem('gcalApiKey', apiKey);
+    clientInput.value = '';
+    apiInput.value = '';
+    status.textContent = 'Keys saved';
+    setTimeout(() => location.reload(), 500);
+  });
+
+  container.querySelector('#clear-gcal-keys').addEventListener('click', () => {
+    localStorage.removeItem('gcalClientId');
+    localStorage.removeItem('gcalApiKey');
+    status.textContent = 'Keys cleared';
+  });
+});

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
     <script src="focus-mode.js" defer></script>
     <script src="reward-system.js" defer></script>
     <script src="calendar-tool.js" defer></script>
+    <script src="calendar-settings.js" defer></script>
     <script src="routine.js" defer></script>
     <script src="script-loader.js" defer></script>
     <script src="i18n.js" defer></script>


### PR DESCRIPTION
## Summary
- Replace README instructions for Google Calendar with a guided form on the Calendar page
- Remove Google Calendar credential fields from the About section
- Add a settings panel on the Calendar page for entering and storing Google Calendar credentials

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc56fa0cec8321b944fdbf40515cca