### PR TITLE
Improve calendar import visibility and credential error handling

### DIFF
--- a/calendar-integration.js
+++ b/calendar-integration.js
@@ -63,12 +63,20 @@ document.addEventListener('DOMContentLoaded', function() {
     
     // Initialize the gapi.client object
     async function initializeGapiClient() {
-        await gapi.client.init({
-            apiKey: API_KEY,
-            discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
-        });
-        gapiInited = true;
-        maybeEnableButtons();
+        try {
+            await gapi.client.init({
+                apiKey: API_KEY,
+                discoveryDocs: ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'],
+            });
+            gapiInited = true;
+            maybeEnableButtons();
+        } catch (err) {
+            console.error('Failed to initialize Google API client:', err);
+            const statusElements = document.querySelectorAll('#calendar-status');
+            statusElements.forEach(el => {
+                el.textContent = 'Invalid API key or Client ID';
+            });
+        }
     }
     
     // Initialize the tokenClient
@@ -108,7 +116,10 @@ document.addEventListener('DOMContentLoaded', function() {
         tokenClient.callback = async (resp) => {
             if (resp.error !== undefined) {
                 statusElements.forEach(el => {
-                    el.textContent = 'Error: ' + resp.error;
+                    const msg = (resp.error === 'invalid_client' || resp.error === 'unauthorized_client')
+                        ? 'Invalid API key or Client ID'
+                        : 'Error: ' + resp.error;
+                    el.textContent = msg;
                 });
                 return;
             }

--- a/calendar-tool.js
+++ b/calendar-tool.js
@@ -510,6 +510,12 @@
     if (window.DataManager && window.DataManager.EventBus) {
       window.DataManager.EventBus.addEventListener('dataChanged', render);
     }
+    if (window.EventBus) {
+      window.EventBus.addEventListener('calendarEventsUpdated', () => {
+        events = loadEvents();
+        render();
+      });
+    }
 
     const defaultBtn = container.querySelector('.calendar-view-btn[data-view="' + currentView + '"]');
     if (defaultBtn) defaultBtn.classList.add('active');


### PR DESCRIPTION
## Summary
- Refresh calendar tool when events are imported so Google Calendar items appear immediately
- Warn users when Google API key or Client ID are invalid during calendar integration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5c239a74832181707734eca175b6