### PR TITLE
Add calendar integration script

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
     <script src="reward-system.js" defer></script>
     <script src="calendar-tool.js" defer></script>
     <script src="calendar-settings.js" defer></script>
+    <script src="calendar-integration.js" defer></script>
     <script src="routine.js" defer></script>
     <script src="script-loader.js" defer></script>
     <script src="i18n.js" defer></script>


### PR DESCRIPTION
## Summary
- Include `calendar-integration.js` in the main HTML to enable Google Calendar features for Day Planner and Task Manager

## Testing
- `npm test` (fails: Error: no test specified)
- `node` simulate page load to verify calendar integration UI renders in planner and tasks

------
https://chatgpt.com/codex/tasks/task_e_68bc61ee12988321a57dd1fca9e7f8ba