### PR TITLE
Fix routine advancement when tasks run overtime

### DIFF
--- a/routine.js
+++ b/routine.js
@@ -793,12 +793,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const isTaskLate = activeTaskTimeLeftSeconds < 0; 
             drawPieChart(percentageRemaining, isTaskLate);
 
-            if (activeTaskTimeLeftSeconds < 0 && originalTaskDurationSeconds <= 0) { 
-                 clearInterval(currentTaskTimer);
-                 currentTaskTimer = null;
-                 currentTaskIndex++;
-                 startNextTask();
-                 return; 
+            if (activeTaskTimeLeftSeconds < 0) {
+                clearInterval(currentTaskTimer);
+                currentTaskTimer = null;
+                currentTaskIndex++;
+                startNextTask();
+                return;
             }
 
             if (activeTaskTimeLeftSeconds <= 0 && !isTaskLate) {


### PR DESCRIPTION
## Summary
- advance to the next routine task when the timer drops below zero

## Testing
- `node routine.test.js` *(fails: Routine functions not available / ctx.moveTo not a function)*
- `npm test` *(fails: no test specified)*
- `node overtime_test.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc620240d88321bfb739320bbadb7b