### PR TITLE
Enable drag-and-drop rescheduling in day planner

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -715,6 +715,7 @@ footer {
     overflow-y: auto;
     height: calc(4 * 60 * var(--minute-height));
     max-height: 80vh;
+    position: relative;
 }
 
 .time-scroll-slider {


### PR DESCRIPTION
## Summary
- Allow planner events to be dragged to new time slots with mouse interactions.
- Update task `plannerDate` when dropping inside valid hours; cancel drag otherwise.
- Prepare container styling for absolute positioning during drag.

## Testing
- `node --check day-planner.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc656e2d0483219d014e1cd2e644cb