### PR TITLE
Show calendar conflicts during routine runs

### DIFF
--- a/index.html
+++ b/index.html
@@ -872,6 +872,7 @@
                             </ul>
                             <p data-i18n="routine-finish-time">Expected Finish Time: <span
                                     id="expected-finish-time">-</span></p>
+                            <p id="routine-calendar-conflicts" class="routine-calendar-conflicts" style="display: none;"></p>
                         </div>
 
                         <div class="routine-controls">


### PR DESCRIPTION
## Summary
- add a routine player notice for overlapping calendar events
- parse locally stored calendar imports to detect collisions with the active routine window
- refresh conflict warnings when a routine starts, ends, or calendar events update

## Testing
- Not run (not provided)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931b6e8a0b883219e6a56569ec28e5e)