### PR TITLE
Add routine rescheduling UI and simplify skip action

### DIFF
--- a/index.html
+++ b/index.html
@@ -885,8 +885,10 @@
                                     <span class="label-text">Auto Run</span>
                                 </label>
                                 <button id="routine-skip-btn" class="btn btn-warning"
-                                    title="Skip current task and reschedule"><i class="fas fa-forward"></i>
+                                    title="Skip current task"><i class="fas fa-forward"></i>
                                     Skip</button>
+                                <button id="routine-reschedule-btn" class="btn btn-secondary"
+                                    title="Reschedule current task">Reschedule</button>
                             </div>
                         </div>
 
@@ -905,6 +907,24 @@
                     </div>
                 </div>
             </section>
+
+            <div id="routine-reschedule-modal" class="routine-reschedule-modal hidden">
+                <div class="routine-reschedule-dialog">
+                    <div class="routine-reschedule-header">
+                        <h3>Reschedule Current Task</h3>
+                        <button id="routine-reschedule-close" class="close-btn" aria-label="Close reschedule window">
+                            <i class="fas fa-times"></i>
+                        </button>
+                    </div>
+                    <p class="routine-reschedule-tip">Drag and drop to move the current task to a different spot in the
+                        queue.</p>
+                    <ul id="routine-reschedule-list" class="routine-reschedule-list"></ul>
+                    <div class="routine-reschedule-actions">
+                        <button id="routine-reschedule-cancel" class="btn btn-secondary">Cancel</button>
+                        <button id="routine-reschedule-save" class="btn btn-primary">Save Order</button>
+                    </div>
+                </div>
+            </div>
 
             <!-- Fullscreen Routine Focus Mode -->
             <div id="routine-focus-mode" class="routine-focus-mode hidden">

--- a/styles.css
+++ b/styles.css
@@ -2497,6 +2497,90 @@ input:checked + .slider:before {
          g a p :   1 r e m ;  
  }  
   
+/* Routine reschedule modal */
+.routine-reschedule-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2000;
+}
+
+.routine-reschedule-modal.hidden {
+    display: none;
+}
+
+.routine-reschedule-dialog {
+    background: #fff;
+    border-radius: 12px;
+    padding: 1.5rem;
+    width: min(480px, 90vw);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.2);
+}
+
+.routine-reschedule-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.routine-reschedule-tip {
+    color: #666;
+    margin-bottom: 1rem;
+}
+
+.routine-reschedule-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.routine-reschedule-item {
+    background: #f8f8f8;
+    border: 1px solid #e2e2e2;
+    border-radius: 8px;
+    padding: 0.75rem;
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    cursor: grab;
+}
+
+.routine-reschedule-item.dragging {
+    opacity: 0.6;
+}
+
+.routine-reschedule-grip {
+    color: #999;
+}
+
+.routine-reschedule-name {
+    flex: 1;
+    font-weight: 600;
+}
+
+.routine-reschedule-meta {
+    color: #777;
+    font-size: 0.9rem;
+}
+
+.routine-reschedule-current {
+    background: #e8f4ff;
+    border-color: #90c2ff;
+}
+
+.routine-reschedule-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
+}
  . c a l e n d a r - h e a d e r - t i t l e   {  
          m a r g i n :   0 ;  
          f o n t - s i z e :   1 . 2 5 r e m ;  


### PR DESCRIPTION
## Summary
- Change routine skip behavior to drop the current task immediately
- Add reschedule button and modal to drag-and-drop the current and upcoming tasks
- Style the new reschedule overlay for clarity

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c6dce4488321a71bd0bac8713a14)