### PR TITLE
Adjust routine player launch and completion feedback

### DIFF
--- a/routine.js
+++ b/routine.js
@@ -275,6 +275,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
         newTabUrl.pathname = '/' + pathSegments.join('/');
         newTabUrl.searchParams.set('autostartRoutine', '1');
+        newTabUrl.searchParams.set('routineView', 'player');
         return newTabUrl.toString();
     }
 
@@ -380,7 +381,12 @@ document.addEventListener('DOMContentLoaded', () => {
     function handlePendingRoutineRun() {
         const params = new URLSearchParams(window.location.search);
         const shouldAutoStart = params.get('autostartRoutine') === '1';
+        const desiredView = params.get('routineView');
         const pendingRunRaw = localStorage.getItem(ROUTINE_RUN_REQUEST_KEY);
+
+        if (desiredView === 'player') {
+            updateRoutineView(true);
+        }
 
         if (!shouldAutoStart || !pendingRunRaw) {
             return;
@@ -1331,7 +1337,7 @@ document.addEventListener('DOMContentLoaded', () => {
             currentTaskTimer = null;
         }
         currentTaskIndex++;
-        notify(`Task "${finishedTask.name}" finished`);
+        console.log(`Task "${finishedTask.name}" finished`);
         startNextTask();
     }
 


### PR DESCRIPTION
## Summary
- add routineView query parameter so new routine tabs open directly in the player
- auto-toggle routine view to the player when the player view is requested during autostart handling
- switch manual task completion feedback to console logging instead of pop-up notifications

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6931c7f8134883219b6d1c240e92c770)