### PR TITLE
Start routine in current tab and shrink queue preview

### DIFF
--- a/routine-focus.css
+++ b/routine-focus.css
@@ -191,15 +191,18 @@
     right: 1.5rem;
     top: 50%;
     transform: translateY(-50%);
-    width: 260px;
+    width: 64px;
+    min-height: 72px;
     background: rgba(0, 0, 0, 0.2);
     color: white;
-    padding: 1rem 1.25rem;
+    padding: 0.75rem;
     border-radius: 14px;
     box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
     backdrop-filter: blur(8px);
-    transition: opacity 0.2s ease, transform 0.2s ease;
+    transition: opacity 0.2s ease, transform 0.2s ease, width 0.2s ease, max-height 0.2s ease;
     z-index: 10000;
+    overflow: hidden;
+    cursor: pointer;
 }
 
 .routine-queue-preview.hidden {
@@ -208,16 +211,43 @@
     transform: translateY(-50%) translateX(10px);
 }
 
+.routine-queue-preview .queue-subtitle,
+.routine-queue-preview #routine-queue-list {
+    opacity: 0;
+    max-height: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, max-height 0.2s ease;
+}
+
+.routine-queue-preview:hover,
+.routine-queue-preview.expanded {
+    width: 280px;
+    max-height: 80vh;
+    overflow-y: auto;
+}
+
+.routine-queue-preview:hover .queue-subtitle,
+.routine-queue-preview:hover #routine-queue-list,
+.routine-queue-preview.expanded .queue-subtitle,
+.routine-queue-preview.expanded #routine-queue-list {
+    opacity: 1;
+    max-height: 60vh;
+    pointer-events: auto;
+}
+
 .routine-queue-header {
     display: flex;
     flex-direction: column;
     gap: 0.15rem;
-    margin-bottom: 0.75rem;
+    margin-bottom: 0.5rem;
 }
 
 .queue-title {
-    font-size: 1.1rem;
+    font-size: 1rem;
     font-weight: 700;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .queue-subtitle {
@@ -231,7 +261,28 @@
     padding: 0;
     display: flex;
     flex-direction: column;
-    gap: 0.35rem;
+    gap: 0.5rem;
+}
+
+@media (max-width: 768px) {
+    .routine-queue-preview {
+        right: 0.75rem;
+        top: auto;
+        bottom: 1rem;
+        transform: none;
+        width: 56px;
+        padding: 0.65rem;
+        max-height: 56px;
+    }
+
+    .routine-queue-preview:hover,
+    .routine-queue-preview.expanded {
+        width: min(85vw, 320px);
+        max-height: 70vh;
+        right: 0.75rem;
+        bottom: 1rem;
+        transform: none;
+    }
 }
 
 .queue-item {


### PR DESCRIPTION
## Summary
- start the selected routine in the current tab, updating the URL without opening a popup
- add hover/tap expand behavior for the next-up queue preview with a compact default footprint
- adjust queue preview styling for mobile so it stays out of the way of routine controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693514a99b6c8321a00a2782854bfb36)