### PR TITLE
Add controls to collapse routine queue

### DIFF
--- a/index.html
+++ b/index.html
@@ -1039,8 +1039,13 @@
 
             <div id="routine-queue-panel" class="routine-queue-preview hidden">
                 <div class="routine-queue-header">
-                    <span class="queue-title">Next Up</span>
-                    <span class="queue-subtitle">Drag to rearrange</span>
+                    <div class="queue-header-text">
+                        <span class="queue-title">Next Up</span>
+                        <span class="queue-subtitle">Drag to rearrange</span>
+                    </div>
+                    <button id="routine-queue-close" class="queue-close-btn" aria-label="Hide Next Up">
+                        <i class="fas fa-times"></i>
+                    </button>
                 </div>
                 <ul id="routine-queue-list"></ul>
             </div>

--- a/routine-focus.css
+++ b/routine-focus.css
@@ -237,9 +237,16 @@
 
 .routine-queue-header {
     display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.queue-header-text {
+    display: flex;
     flex-direction: column;
     gap: 0.15rem;
-    margin-bottom: 0.5rem;
+    flex: 1;
 }
 
 .queue-title {
@@ -248,6 +255,24 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.queue-close-btn {
+    background: rgba(255, 255, 255, 0.15);
+    border: none;
+    color: white;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    display: grid;
+    place-items: center;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.queue-close-btn:hover {
+    background: rgba(255, 255, 255, 0.25);
+    transform: translateY(-1px);
 }
 
 .queue-subtitle {

--- a/routine.js
+++ b/routine.js
@@ -1861,6 +1861,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const focusAutoRunCheckbox = document.getElementById('focus-auto-run');
     const queuePreviewPanel = document.getElementById('routine-queue-panel');
     const queuePreviewList = document.getElementById('routine-queue-list');
+    const queuePreviewCloseBtn = document.getElementById('routine-queue-close');
     const queueDropIndicator = document.createElement('li');
     queueDropIndicator.className = 'queue-drop-indicator';
     queueDropIndicator.textContent = 'Release to place';
@@ -1868,6 +1869,14 @@ document.addEventListener('DOMContentLoaded', () => {
     let queueDropIndex = null;
     let isQueueDragging = false;
     let queuePreviewLockedOpen = false;
+
+    function isQueueExpanded() {
+        return queuePreviewPanel && (
+            queuePreviewLockedOpen ||
+            queuePreviewPanel.classList.contains('expanded') ||
+            queuePreviewPanel.matches(':hover')
+        );
+    }
 
     function expandQueuePreview() {
         if (!queuePreviewPanel) return;
@@ -1894,6 +1903,32 @@ document.addEventListener('DOMContentLoaded', () => {
             if (queuePreviewLockedOpen) {
                 expandQueuePreview();
             } else {
+                collapseQueuePreview(true);
+            }
+        });
+    }
+
+    if (queuePreviewCloseBtn) {
+        queuePreviewCloseBtn.addEventListener('click', (event) => {
+            event.stopPropagation();
+            if (isQueueExpanded()) {
+                collapseQueuePreview(true);
+                return;
+            }
+
+            if (typeof exitFocusMode === 'function') {
+                exitFocusMode();
+            }
+        });
+    }
+
+    if (focusModeEl) {
+        focusModeEl.addEventListener('click', (event) => {
+            if (!queuePreviewPanel || !isQueueExpanded()) return;
+            if (queuePreviewPanel.contains(event.target)) return;
+
+            const clickedLeftSide = event.clientX < window.innerWidth / 2;
+            if (clickedLeftSide) {
                 collapseQueuePreview(true);
             }
         });


### PR DESCRIPTION
## Summary
- add a close control to the Next Up queue panel
- allow collapsing the queue by clicking the left side of the focus view or the new close button
- reuse the close button to exit focus mode when the queue is already minimized

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693520cb5ed083219f319910e82cf2f2)