### PR TITLE
Add unified task model, store, and scheduler foundation

### DIFF
--- a/core/task-model.js
+++ b/core/task-model.js
@@ -1,3 +1,5 @@
+const DEFAULT_USER = 'main';
+
 function getConfig() {
   if (typeof window !== 'undefined') {
     const cfg = window.ConfigManager?.getConfig?.() || window.ConfigManager?.DEFAULT_CONFIG;
@@ -6,41 +8,118 @@ function getConfig() {
   return { defaultTaskMinutes: 25 };
 }
 
-function generateId() {
-  if (typeof window !== 'undefined' && window.CrossTool?.generateId) {
-    return window.CrossTool.generateId();
-  }
-  if (typeof window !== 'undefined' && window.DataManager?.generateId) {
-    return window.DataManager.generateId();
-  }
-  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID();
-  }
-  return 'task-' + Date.now() + '-' + Math.floor(Math.random() * 1000);
+function normalizeNumber(val, fallback) {
+  const num = Number(val);
+  return Number.isFinite(num) ? num : fallback;
 }
 
-export function createTask(raw = {}, overrides = {}) {
-  return {
-    id: raw.id ?? generateId(),
-    title: raw.title ?? '',
-    source: raw.source ?? 'manual',
-    importance: raw.importance ?? 5,
-    urgency: raw.urgency ?? 5,
-    estimatedMinutes: raw.estimatedMinutes ?? getConfig().defaultTaskMinutes,
+function computeUrgencyFromDeadline(deadline) {
+  if (!deadline) return 5;
+  const now = new Date();
+  const due = new Date(deadline);
+  if (isNaN(due.getTime())) return 5;
+  const diffDays = Math.floor((due.setHours(0, 0, 0, 0) - now.setHours(0, 0, 0, 0)) / (1000 * 60 * 60 * 24));
+  if (diffDays <= 0) return 10;
+  if (diffDays === 1) return 9;
+  if (diffDays <= 3) return 8;
+  if (diffDays <= 5) return 7;
+  if (diffDays <= 7) return 6;
+  return 5;
+}
+
+function baseHash(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i += 1) {
+    hash = ((hash << 5) - hash) + str.charCodeAt(i);
+    hash |= 0;
+  }
+  return `task-${Math.abs(hash)}`;
+}
+
+function generateHash({ user, name, createdAt, seed }) {
+  const basis = `${user || DEFAULT_USER}|${name || 'task'}|${createdAt || new Date().toISOString()}|${seed || ''}`;
+  return baseHash(basis);
+}
+
+function computeAchievementScore(task) {
+  const durationHours = normalizeNumber(task.durationMinutes, 0) / 60;
+  const importance = normalizeNumber(task.importance, 0);
+  const score = importance * durationHours;
+  return Number.isFinite(score) ? Number(score.toFixed(2)) : 0;
+}
+
+function createTask(raw = {}, overrides = {}) {
+  const cfg = getConfig();
+  const createdAt = raw.createdAt || new Date().toISOString();
+  const user = raw.user || DEFAULT_USER;
+  const name = raw.name || raw.title || raw.text || 'Untitled Task';
+  const deadline = raw.deadline || raw.plannerDate || null;
+  const durationMinutes = normalizeNumber(
+    raw.durationMinutes ?? raw.duration ?? raw.estimatedMinutes,
+    normalizeNumber(cfg?.defaultTaskMinutes, 60)
+  );
+  const importance = normalizeNumber(raw.importance ?? raw.priority, 5);
+  const urgency = normalizeNumber(raw.urgency, computeUrgencyFromDeadline(deadline));
+  const base = {
+    user,
+    name,
+    text: raw.text || name,
+    createdAt,
+    deadline,
+    plannerDate: raw.plannerDate || null,
+    startTime: raw.startTime || null,
+    durationMinutes,
+    importance: Math.max(1, Math.min(10, importance || 1)),
+    urgency: Math.max(1, Math.min(10, urgency || 1)),
+    dependency: raw.dependency || raw.dependsOn || null,
+    completed: Boolean(raw.completed || raw.isCompleted),
+    completedAt: raw.completedAt || null,
+    achievementScore: normalizeNumber(raw.achievementScore, 0),
     isFixed: raw.isFixed ?? false,
-    startTime: raw.startTime ?? null,
-    durationMinutes: raw.durationMinutes ?? raw.estimatedMinutes ?? getConfig().defaultTaskMinutes,
-    calendarUid: raw.calendarUid ?? null,
-    calendarInstanceId: raw.calendarInstanceId ?? null,
-    assignedTo: raw.assignedTo ?? null,
-    iconId: raw.iconId ?? null,
-    status: raw.status ?? 'pending',
-    ...overrides,
+    source: raw.source || raw.originalTool || 'manual',
+    originalTool: raw.originalTool || raw.source || 'manual',
   };
+  const hash = raw.hash || raw.id || generateHash(base);
+  const task = {
+    ...base,
+    hash,
+    id: raw.id || hash,
+  };
+  if (task.completed && !task.completedAt) {
+    task.completedAt = new Date().toISOString();
+  }
+  const merged = { ...task, ...overrides };
+  if (!merged.achievementScore && merged.completed) {
+    merged.achievementScore = computeAchievementScore(merged);
+  }
+  return merged;
+}
+
+function updateTask(task, updates) {
+  return createTask({ ...task, ...updates, createdAt: task.createdAt || new Date().toISOString(), hash: task.hash, id: task.id }, {});
+}
+
+function markTaskCompleted(task, completedAt = new Date().toISOString()) {
+  const updated = updateTask(task, { completed: true, completedAt });
+  return { ...updated, achievementScore: computeAchievementScore(updated) };
 }
 
 if (typeof window !== 'undefined') {
-  window.TaskModel = { createTask };
+  window.TaskModel = {
+    createTask,
+    updateTask,
+    markTaskCompleted,
+    computeUrgencyFromDeadline,
+    computeAchievementScore,
+    DEFAULT_USER,
+  };
 }
 
-export default { createTask };
+export default {
+  createTask,
+  updateTask,
+  markTaskCompleted,
+  computeUrgencyFromDeadline,
+  computeAchievementScore,
+  DEFAULT_USER,
+};

--- a/core/task-store.js
+++ b/core/task-store.js
@@ -1,0 +1,123 @@
+import { createTask, updateTask, markTaskCompleted } from './task-model.js';
+
+const STORAGE_KEY = 'adhd-unified-tasks';
+
+function readLegacyTasks() {
+  try {
+    const raw = localStorage.getItem('adhd-hub-data');
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed?.tasks) ? parsed.tasks : [];
+  } catch (err) {
+    console.warn('Failed to read legacy tasks', err);
+    return [];
+  }
+}
+
+function loadTasks() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return readLegacyTasks().map(t => createTask(t, { hash: t.id || t.hash }));
+    }
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed.map(t => createTask(t, t)) : [];
+  } catch (err) {
+    console.error('Failed to load unified tasks', err);
+    return [];
+  }
+}
+
+let tasks = loadTasks();
+
+function persist() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+  } catch (err) {
+    console.error('Failed to save unified tasks', err);
+  }
+}
+
+function getAllTasks() {
+  return [...tasks];
+}
+
+function getTasksByUser(user) {
+  return tasks.filter(t => t.user === user);
+}
+
+function getTaskByHash(hash) {
+  return tasks.find(t => t.hash === hash || t.id === hash) || null;
+}
+
+function getPendingTasks() {
+  return tasks.filter(t => !t.completed);
+}
+
+function addTask(rawTask) {
+  const task = createTask(rawTask, rawTask);
+  tasks.push(task);
+  persist();
+  return task;
+}
+
+function updateTaskByHash(hash, updates) {
+  const idx = tasks.findIndex(t => t.hash === hash || t.id === hash);
+  if (idx === -1) return null;
+  const updated = updateTask(tasks[idx], updates);
+  tasks[idx] = updated;
+  persist();
+  return updated;
+}
+
+function upsertTaskByHash(hash, rawTask) {
+  const existing = getTaskByHash(hash);
+  if (!existing) return addTask({ ...rawTask, hash });
+  return updateTaskByHash(existing.hash, rawTask);
+}
+
+function saveTasks(nextTasks) {
+  tasks = nextTasks.map(t => createTask(t, t));
+  persist();
+}
+
+function markComplete(hash, completedAt = new Date().toISOString()) {
+  const task = getTaskByHash(hash);
+  if (!task) return null;
+  const updated = markTaskCompleted(task, completedAt);
+  return updateTaskByHash(hash, updated);
+}
+
+function getTaskScoreTotals() {
+  const totals = tasks.reduce((acc, task) => {
+    const name = task.name || 'Task';
+    if (!acc[name]) {
+      acc[name] = { name, count: 0, score: 0 };
+    }
+    acc[name].count += task.completed ? 1 : 0;
+    acc[name].score += task.completed ? (task.achievementScore || 0) : 0;
+    return acc;
+  }, {});
+  const groups = Object.values(totals).map(group => ({ ...group, score: Number(group.score.toFixed(2)) }));
+  const totalScore = groups.reduce((sum, g) => sum + g.score, 0);
+  return { groups, totalScore: Number(totalScore.toFixed(2)) };
+}
+
+const TaskStore = {
+  getAllTasks,
+  getTasksByUser,
+  getTaskByHash,
+  getPendingTasks,
+  addTask,
+  updateTaskByHash,
+  upsertTaskByHash,
+  saveTasks,
+  markComplete,
+  getTaskScoreTotals,
+};
+
+if (typeof window !== 'undefined') {
+  window.TaskStore = TaskStore;
+}
+
+export default TaskStore;

--- a/dayPlannerUtils.js
+++ b/dayPlannerUtils.js
@@ -9,6 +9,12 @@ function getConfig() {
     return (window.ConfigManager?.getConfig?.() || window.ConfigManager?.DEFAULT_CONFIG || {});
 }
 
+function getUnifiedTasks() {
+    if (window.TaskStore?.getAllTasks) return window.TaskStore.getAllTasks();
+    if (window.DataManager?.getTasks) return window.DataManager.getTasks();
+    return [];
+}
+
 function getTagConfig() {
     const cfg = getConfig();
     return {
@@ -57,11 +63,9 @@ export function getDefaultDurationMinutes() {
 }
 
 export function getPlannerTasksForDay(currentDate) {
-    if (!window.DataManager) return [];
-
     const cfg = getConfig();
     const plannerDateStr = currentDate.toISOString().slice(0, 10);
-    const tasks = window.DataManager.getTasks();
+    const tasks = getUnifiedTasks();
     const defaultDuration = getDefaultDurationMinutes();
 
     const todaysTasks = tasks.filter(task => task.plannerDate && task.plannerDate.startsWith(plannerDateStr));
@@ -150,11 +154,11 @@ export function populateTimeOptions(select) {
 
 export function populateTaskOptions(select) {
     select.innerHTML = '<option value="">-- New Event --</option>';
-    const tasks = window.DataManager.getTasks().filter(t => !t.plannerDate);
+    const tasks = getUnifiedTasks().filter(t => !t.plannerDate && !t.completed);
     tasks.forEach(t => {
         const opt = document.createElement('option');
-        opt.value = t.id;
-        opt.textContent = t.text;
+        opt.value = t.hash || t.id;
+        opt.textContent = t.name || t.text;
         select.appendChild(opt);
     });
 }


### PR DESCRIPTION
## Summary
- introduce a shared Task model with deterministic hashes, urgency/achievement helpers, and cross-tool normalization
- add a unified task store persisted in localStorage and wire DataManager, Day Planner, and Routine quick tasks through it
- expose a basic scheduler plus achievement-backed rewards/points handling and document the new architecture in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935445489f48321aeba73dae1be79eb)