### PR TITLE
Add scheduler-driven planner updates and today view

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,10 +142,25 @@ Legacy modules still calling `DataManager` automatically read/write through this
 *   **Focus Mode:** Minimize distractions with a clean, focused interface.
 *   **Rewards:** Celebrate your accomplishments with visual rewards.
 *   **Calendar Tool:** Import events from ICS files and integrate them with other tools.
+*   **Unified Scheduler:** Generate a daily schedule across tools using shared TaskStore data and calendar blocks.
+*   **Today View:** A lightweight dashboard that surfaces the current task, upcoming items, and quick actions.
 
 ## Privacy
 
 All data is stored locally in your browser. Nothing is sent to any server, ensuring your information remains private.
+
+## Unified Scheduler & TaskStore
+
+`core/scheduler.js` exposes `getTodaySchedule()` and `getCurrentTask()` to produce a prioritized plan for the current day. The scheduler:
+
+* reads tasks from the shared **TaskStore** (including routines, planner items, and calendar imports),
+* excludes completed or dependency-blocked tasks,
+* blocks out fixed calendar events and `[FIX]`-tagged items,
+* scores tasks with `importance × urgency`, then fills open time in priority order.
+
+The Day Planner includes a **Generate schedule for today** action that applies the scheduler to the timeline, and the **Start Focus Session for Current Task** button boots focus mode with the active slot.
+
+The **Today View** (on the Home tab) highlights the current task, the next three items, and quick actions to start focus, mark done (updates TaskStore), or skip/reschedule with higher urgency.
 
 ## Feedback
 
@@ -201,6 +216,8 @@ The Calendar tool can load `.ics` files exported from other apps like Google Cal
    - In **Google Calendar** open **Settings → Import & export** and choose **Export** to download a ZIP containing your calendars. Extract the `.ics` file from it.
 2. Open the **Calendar** tool and click **Import ICS**.
 3. Select the `.ics` file and the events will appear in the list and be stored locally.
+
+Imported calendar events are converted into TaskStore entries using deterministic hashes based on the ICS UID and start time. `[FIX]` and `[FLEX]` tags set whether the scheduler treats them as fixed or flexible blocks.
 
 Only simple events are supported and nothing is uploaded anywhere.
 

--- a/core/task-store.js
+++ b/core/task-store.js
@@ -1,4 +1,4 @@
-import { createTask, updateTask, markTaskCompleted } from './task-model.js';
+import { createTask, updateTask, markTaskCompleted, computeAchievementScore } from './task-model.js';
 
 const STORAGE_KEY = 'adhd-unified-tasks';
 
@@ -94,8 +94,9 @@ function getTaskScoreTotals() {
     if (!acc[name]) {
       acc[name] = { name, count: 0, score: 0 };
     }
+    const score = task.completed ? (task.achievementScore || computeAchievementScore(task) || 0) : 0;
     acc[name].count += task.completed ? 1 : 0;
-    acc[name].score += task.completed ? (task.achievementScore || 0) : 0;
+    acc[name].score += score;
     return acc;
   }, {});
   const groups = Object.values(totals).map(group => ({ ...group, score: Number(group.score.toFixed(2)) }));

--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
     <script src="habit-tracker.js" defer></script>
     <script src="focus-mode.js" defer></script>
     <script src="reward-system.js" defer></script>
+    <script src="today-view.js" defer></script>
     <script src="calendar-tool.js" defer></script>
     <script src="calendar-settings.js" defer></script>
     <script src="calendar-integration.js" defer></script>
@@ -84,6 +85,22 @@
                 <h2 data-i18n="home-heading">Welcome to ADHD Tools Hub</h2>
                 <p data-i18n="home-text">This website provides a collection of interactive tools designed specifically
                     to help individuals with ADHD manage their symptoms, improve productivity, and enhance focus.</p>
+
+                <div id="today-view" class="today-view">
+                    <div class="today-current">
+                        <h3>Current Task</h3>
+                        <div id="today-current-task" class="today-card">No active task yet.</div>
+                        <div class="today-actions">
+                            <button id="today-start-focus" class="btn btn-primary"><i class="fas fa-play"></i> Start Focus Session</button>
+                            <button id="today-mark-done" class="btn btn-secondary"><i class="fas fa-check"></i> Mark Done</button>
+                            <button id="today-skip" class="btn btn-outline"><i class="fas fa-forward"></i> Skip / Reschedule</button>
+                        </div>
+                    </div>
+                    <div class="today-next">
+                        <h3>Up Next</h3>
+                        <ul id="today-next-list" class="today-list"></ul>
+                    </div>
+                </div>
 
                 <div class="tools-grid">
                     <div class="tool-card" data-tool="pomodoro">
@@ -191,6 +208,9 @@
                             <button id="clear-events-btn" class="btn btn-secondary">
                                 <i class="fas fa-trash"></i> <span class="btn-text">Clear All</span>
                             </button>
+                            <button id="generate-schedule-btn" class="btn btn-secondary">
+                                <i class="fas fa-calendar-check"></i> <span class="btn-text">Generate schedule for today</span>
+                            </button>
                             <button id="ai-plan-day-btn" class="btn btn-secondary">
                                 <i class="fas fa-magic"></i> <span class="btn-text">AI Plan</span>
                             </button>
@@ -199,6 +219,9 @@
                             </button>
                             <button id="record-event-btn" class="btn btn-secondary">
                                 <i class="fas fa-microphone"></i> <span class="btn-text">Record</span>
+                            </button>
+                            <button id="start-focus-from-planner" class="btn btn-primary">
+                                <i class="fas fa-play"></i> <span class="btn-text">Start Focus Session for Current Task</span>
                             </button>
                         </div>
                     </div>
@@ -224,6 +247,12 @@
                             <select id="event-time"></select>
                             <label for="event-duration">Duration (minutes):</label>
                             <input type="number" id="event-duration" min="5" step="5" value="60" required>
+                            <label for="event-importance">Importance (1-10):</label>
+                            <input type="number" id="event-importance" min="1" max="10" step="1" value="5">
+                            <label for="event-urgency">Urgency (1-10):</label>
+                            <input type="number" id="event-urgency" min="1" max="10" step="1" value="5">
+                            <label for="event-deadline">Deadline:</label>
+                            <input type="datetime-local" id="event-deadline">
                             <button type="submit" class="btn">Save Event</button>
                         </form>
                     </div>

--- a/styles.css
+++ b/styles.css
@@ -2905,7 +2905,73 @@ input:checked + .slider:before {
          b o r d e r - r a d i u s :   6 p x ;  
          f o n t - s i z e :   0 . 9 r e m ;  
          f o n t - w e i g h t :   5 0 0 ;  
-         c o l o r :   # 6 6 6 ;  
+ 
+/* Today view & responsive tweaks */
+.today-view {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    margin: 20px 0;
+}
+
+.today-card {
+    background: #fff;
+    border-radius: 8px;
+    padding: 12px;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.06);
+}
+
+.today-actions {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+    margin-top: 10px;
+}
+
+.today-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.today-list li {
+    padding: 8px;
+    background: #fff;
+    border-radius: 6px;
+    margin-bottom: 6px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
+}
+
+@media (max-width: 820px) {
+    nav .container {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    #main-nav-links {
+        display: none;
+        width: 100%;
+        flex-wrap: wrap;
+    }
+
+    #main-nav-links.nav-open {
+        display: flex;
+    }
+
+    nav ul li {
+        width: 100%;
+        margin: 4px 0;
+    }
+
+    .modal-content {
+        width: 95%;
+    }
+
+    .today-view {
+        grid-template-columns: 1fr;
+    }
+}
+ 
          c u r s o r :   p o i n t e r ;  
  }  
   

--- a/today-view.js
+++ b/today-view.js
@@ -1,0 +1,86 @@
+(function() {
+  document.addEventListener('DOMContentLoaded', () => {
+    const currentEl = document.getElementById('today-current-task');
+    const nextList = document.getElementById('today-next-list');
+    const startBtn = document.getElementById('today-start-focus');
+    const doneBtn = document.getElementById('today-mark-done');
+    const skipBtn = document.getElementById('today-skip');
+
+    if (!currentEl || !nextList) return;
+
+    const scheduler = () => window.UnifiedScheduler || window.TaskScheduler;
+
+    function formatTime(dateObj) {
+      return dateObj?.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) || '';
+    }
+
+    function updateView() {
+      const sched = scheduler();
+      if (!sched?.getTodaySchedule) return;
+      const now = new Date();
+      const schedule = sched.getTodaySchedule(now);
+      const currentSlot = sched.getCurrentTask(now);
+
+      if (currentSlot) {
+        currentEl.textContent = `${currentSlot.task.name || currentSlot.task.text || 'Task'} (${formatTime(currentSlot.startTime)} - ${formatTime(currentSlot.endTime)})`;
+        currentEl.dataset.hash = currentSlot.task.hash || '';
+      } else {
+        currentEl.textContent = 'No active task right now.';
+        currentEl.dataset.hash = '';
+      }
+
+      nextList.innerHTML = '';
+      schedule
+        .filter(slot => slot.startTime > now)
+        .slice(0, 3)
+        .forEach(slot => {
+          const li = document.createElement('li');
+          li.textContent = `${formatTime(slot.startTime)} – ${slot.task.name || slot.task.text || 'Task'}`;
+          nextList.appendChild(li);
+        });
+    }
+
+    function startFocus(taskName) {
+      const goalInput = document.getElementById('focus-goal');
+      if (goalInput) goalInput.value = taskName;
+      document.getElementById('enter-focus-mode')?.click();
+    }
+
+    if (startBtn) {
+      startBtn.addEventListener('click', () => {
+        const sched = scheduler();
+        const slot = sched?.getCurrentTask ? sched.getCurrentTask(new Date()) : null;
+        if (!slot) return alert('No current task to focus on.');
+        startFocus(slot.task.name || slot.task.text || 'Focus');
+      });
+    }
+
+    if (doneBtn) {
+      doneBtn.addEventListener('click', () => {
+        const hash = currentEl.dataset.hash;
+        if (!hash || !window.TaskStore?.markComplete) return;
+        window.TaskStore.markComplete(hash);
+        window.EventBus?.dispatchEvent(new Event('dataChanged'));
+        updateView();
+      });
+    }
+
+    if (skipBtn) {
+      skipBtn.addEventListener('click', () => {
+        const sched = scheduler();
+        const slot = sched?.getCurrentTask ? sched.getCurrentTask(new Date()) : null;
+        if (!slot || !slot.task?.hash || !window.TaskStore?.updateTaskByHash) return;
+        const newUrgency = Math.min(10, Number(slot.task.urgency || 5) + 2);
+        const newStart = new Date(slot.endTime.getTime() + 60 * 60000);
+        const plannerDate = `${newStart.toISOString().slice(0, 10)}T${newStart.toISOString().slice(11, 16)}`;
+        window.TaskStore.updateTaskByHash(slot.task.hash, { plannerDate, urgency: newUrgency });
+        window.EventBus?.dispatchEvent(new Event('dataChanged'));
+        updateView();
+      });
+    }
+
+    window.EventBus?.addEventListener('dataChanged', updateView);
+    setInterval(updateView, 60000);
+    updateView();
+  });
+})();


### PR DESCRIPTION
## Summary
- extend unified scheduler to expose buildSchedule, block calendar events, and power day planner timeline generation
- make planner events editable with importance/urgency/deadline, plus new focus-session and schedule-generation actions
- add Today View dashboard, mobile-responsive tweaks, and convert imported ICS events into TaskStore tasks

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69354a2e5d708321a908152fe714a85f)