### PR TITLE
Fix routine auto-run toggle and improve active task display

### DIFF
--- a/styles-routine-settings.css
+++ b/styles-routine-settings.css
@@ -102,3 +102,13 @@
     background: #ffebee;
     border-radius: 4px;
 }
+
+.routine-task-list .active-task {
+    font-weight: 700;
+    color: #2e7d32;
+}
+
+.routine-task-list .completed-task {
+    color: #6b7280;
+    text-decoration: line-through;
+}


### PR DESCRIPTION
## Summary
- connect the Routine tool auto-run toggle to the underlying timer behavior
- block starting routines that have no tasks and keep the active routine task list visible
- add styling to highlight the current and completed tasks while a routine runs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e6991e0148321a732d9e901d6976a)